### PR TITLE
Fixed typos in the wrangling-genomics lessons

### DIFF
--- a/lessons/00-readQC.md
+++ b/lessons/00-readQC.md
@@ -38,7 +38,7 @@ Notice that line 4 is:
 ```
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ```
-As mentioned above, line 4 is a encoding of the quality. In this case, the code is the [ASCII](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_code_chart) character table. According to the chart a '#' has the value 35 and '!' has the value 33 - **But these values are not actually the quality scores!** There are actually several historical differences in how Illumina and other players have encoded the scores. Heres the chart from wikipedia:
+As mentioned above, line 4 is a encoding of the quality. In this case, the code is the [ASCII](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_code_chart) character table. According to the chart a '#' has the value 35 and '!' has the value 33 - **But these values are not actually the quality scores!** There are actually several historical differences in how Illumina and other players have encoded the scores. Here's the chart from wikipedia:
 
 ```
   SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS.....................................................
@@ -63,7 +63,7 @@ As mentioned above, line 4 is a encoding of the quality. In this case, the code 
      (Note: See discussion above).
  L - Illumina 1.8+ Phred+33,  raw reads typically (0, 41)
  ```
- So using the Illumina 1.8 encouding, which is what you will mostly see from now on, our first c is called with a Phred score of 0 and our Ns are called with a score of 2. Read quality is assessed using the Phred Quality Score.  This score is logarithmically based and the score values can be interpreted as follows:
+ So using the Illumina 1.8 encoding, which is what you will mostly see from now on, our first C is called with a Phred score of 0 and our Ns are called with a score of 2. Read quality is assessed using the Phred Quality Score.  This score is logarithmically based and the score values can be interpreted as follows:
 
 |Phred Quality Score |Probability of incorrect base call |Base call accuracy|
 |:-------------------|:---------------------------------:|-----------------:|
@@ -75,7 +75,7 @@ As mentioned above, line 4 is a encoding of the quality. In this case, the code 
 |60	|1 in 1,000,000|	99.9999%|
 
 ## FastQC
-FastQC (http://www.bioinformatics.babraham.ac.uk/projects/fastqc/) provides a simple way to do some quality control checks on raw sequence data coming from high throughput sequencing pipelines. It provides a modular set of analyses which you can use to give a quick impression of whether your data has any problems of which you should be aware before doing any further analysis.
+FastQC (http://www.bioinformatics.babraham.ac.uk/projects/fastqc/) provides a simple way to do some quality control checks on raw sequence data coming from high throughput sequencing pipelines. It provides a modular set of analyses which you can use to get a quick impression of whether your data has any problems of which you should be aware before doing any further analysis.
 
 The main functions of FastQC are
 * Import of data from BAM, SAM or FastQ files (any variant)
@@ -96,7 +96,7 @@ The main functions of FastQC are
     
     $ mkdir dc_workshop
     ```
-2. Create three three subdirectories
+2. Create three subdirectories
 
    ```bash
     mkdir dc_workshop/data
@@ -133,9 +133,10 @@ Now, let's create a home for our results
     $ mv *.zip ~/dc_workshop/results/fastqc_untrimmed_reads/
     $ mv *.html ~/dc_workshop/results/fastqc_untrimmed_reads/
     ```
+
 ### C. Results
 
-Lets examine the results in detail
+Let's examine the results in detail
 
 1. Navigate to the results and view the directory contents
 
@@ -188,11 +189,11 @@ Once we have an idea of the quality of our raw data, it is time to trim away ada
 
 Because *Trimmomatic* is java based, it is run using the command:
 
-**_java jar trimmomatic-0.32.jar_**
+**_java -jar trimmomatic-0.32.jar_**
 
 What follows this are the specific commands that tells the program exactly how you want it to operate. *Trimmomatic* has a variety of options and parameters:
 
-* **_-threds_** How many processors do you want *Trimmomatic* to run with?
+* **_-threads_** How many processors do you want *Trimmomatic* to run with?
 * **_SE_** or **_PE_** Single End or Paired End reads?
 * **_-phred33_** or **_-phred64_** Which quality score do your reads have?
 * **_SLIDINGWINDOW_** Perform sliding window trimming, cutting once the average quality within the window falls below a threshold.
@@ -206,13 +207,13 @@ What follows this are the specific commands that tells the program exactly how y
 
 A generic command for *Trimmomatic* looks like this:
 
-**java jar trimmomatic-0.32.jar SE -thr**
+**java -jar trimmomatic-0.32.jar SE**
 
 A complete command for *Trimmomatic* will look something like this:
 
-**java jar trimmomatic-0.32.jar SE -threads 4 -phred64 SRR_1056.fastq SRR_1056_trimmed.fastq ILLUMINACLIP:SRR_adapters.fa SLIDINGWINDOW:4:20**
+**java -jar trimmomatic-0.32.jar SE -threads 4 -phred64 SRR_1056.fastq SRR_1056_trimmed.fastq ILLUMINACLIP:SRR_adapters.fa SLIDINGWINDOW:4:20**
 
-This command tells *Trimmomatic* to run on a Single End file (``SRR_0156.fastq``, in this case), the output file will be called ``SRR_0156_trimmed.fastq``,  there is a file with Illumina adapters called ``SRR_adapters.fa``, and we are using a sliding window of size 4 that will remove those bases if their phred score is below 20.
+This command tells *Trimmomatic* to run on a Single End file (``SRR_0156.fastq``, in this case), the output file will be called ``SRR_0156_trimmed.fastq``,  there is a file with Illumina adapters called ``SRR_adapters.fa``, and we are using a sliding window of size 4 that will remove bases with a phred score of below 20.
 
 
 ## Exercise - Running Trimmomatic
@@ -223,16 +224,16 @@ This command tells *Trimmomatic* to run on a Single End file (``SRR_0156.fastq``
 $ cd /home/dcuser/dc_workshop/data/untrimmed_fastq
 ```
 
-The command line incantation for trimmomatic is more complicated.  This is where what you have been learning about accessing your command line history will start to become important.
+The command line invocation for trimmomatic is more complicated.  This is where what you have been learning about accessing your command line history will start to become important.
 
 The general form of the command is:
 
    ```bash
 java -jar ~/Trimmomatic-0.32/trimmomatic-0.32.jar inputfile outputfile OPTION:VALUE...
 ```    
-'java -jar' calls the Java program, which is needed to run trimmomargumentstic, which lived in a 'jar' file (trimmomatic-0.32.jar), a special kind of java archive that is often used for programs written in the Java programing language.  If you see a new program that ends in '.jar', you will know it is a java program that is executed 'java -jar program name'.  The 'SE' argument is a keyword that specifies we are working with single-end reads.
+'java -jar' calls the Java program, which is needed to run trimmomatic, which lives in a 'jar' file (trimmomatic-0.32.jar), a special kind of java archive that is often used for programs written in the Java programing language.  If you see a new program that ends in '.jar', you will know it is a java program that is executed 'java -jar program name'.  The 'SE' argument is a keyword that specifies we are working with single-end reads.
 
-The next two arguments are input file and output file names.  These are then followed by a series of options. The specifics of how options are passed to a program are different depending on the program. You will always have to read the manual of a new program to learn which way it expects its command-line arguments to be composed.
+The next two arguments are input file and output file names.  These are then followed by a series of options. The specifics of how options are passed to a program differ depending on the program. You will always have to read the manual of a new program to learn which way it expects its command-line arguments to be composed.
 
 
 So, for the single fastq input file 'SRR098283.fastq', the command would be:
@@ -253,10 +254,7 @@ So that worked and we have a new fastq file.
     SRR098283.fastq  SRR098283.fastq_trim.fastq
 ```
 
-Now we know how to run trimmomatic but there is some good news and bad news.  
-One should always ask for the bad news first.  Trimmomatic only operates on 
-one input file at a time and we have more than one input file.  The good news?
-We already know how to use a for loop to deal with this situation.
+Now we know how to run trimmomatic but there is some good news and bad news.  One should always ask for the bad news first.  Trimmomatic only operates on one input file at a time and we have more than one input file.  The good news? We already know how to use a for loop to deal with this situation.
 
 ```bash
 $ for infile in *.fastq
@@ -266,7 +264,7 @@ $ for infile in *.fastq
     >done
 ```
 
-Do you remember how the first specifies a variable that is assigned the value of each item in the list in turn?  We can call it whatever we like.  This time it is called infile.  Note that the third line of this for loop is creating a second variable called outfile.  We assign it the value of $infile with '_trim.fastq' appended to it.  The '\' escape character is used so the shell knows that whatever follows \ is not part of the variable name $infile.  There are no spaces before or after the '='.
+Do you remember how the first word after "for" in the loop specifies a variable that is assigned the value of each item in the list in turn?  We can call it whatever we like.  This time it is called infile.  Note that the third line of this for loop is creating a second variable called outfile.  We assign it the value of $infile with '_trim.fastq' appended to it.  The '\' escape character is used so the shell knows that whatever follows \ is not part of the variable name $infile.  There are no spaces before or after the '='.
 
 
 

--- a/lessons/01-automating_a_workflow.md
+++ b/lessons/01-automating_a_workflow.md
@@ -39,7 +39,7 @@ In this case, the interpreter is bash, which is the shell environment we are wor
 make the script executable like a 'real' program.
 
 ## How to run a shell script
-There are two ways to run a shell script the first way is to specify the
+There are two ways to run a shell script. The first way is to specify the
 interpreter (bash) and the name of the script.  By convention, shell script
 use the .sh extension, though this is not enforced.
 
@@ -49,7 +49,7 @@ My file name is untrimmed_fastq/SRR097977.fastq
 My file name is untrimmed_fastq/SRR098026.fastq
 ```
 
-The second was is a little more complicated to set up and requires the shebang line we talked about earlier.
+The second way is a little more complicated to set up and requires the shebang line we talked about earlier.
 
 The first step, which only needs to be done once, is to modify the 'permissions' of the text file so that the shell knows the file is executable.
 
@@ -66,7 +66,7 @@ My file name is untrimmed_fastq/SRR097977.fastq
 My file name is untrimmed_fastq/SRR098026.fastq
 ```
 
-The thing about running programs on the command line is that the shell may not know the location of your executables unless they are in the 'path' of know locations for programs.  So, you need to tell the shell the path to your script, which is './' if it is in the same directory.
+The thing about running programs on the command line is that the shell may not know the location of your executables unless they are in the 'path' of known locations for programs.  So, you need to tell the shell the path to your script, which is './' if it is in the same directory.
 
 ****
 **Exercise**

--- a/lessons/02-variant-calling-workflow.md
+++ b/lessons/02-variant-calling-workflow.md
@@ -78,7 +78,7 @@ bwa index $genome
 samtools faidx $genome
 ```
 
-Create output paths for various intermediate and result files The -p option means mkdir will create the whole path if it does not exist (no error or message will give given if it does exist)
+Create output paths for various intermediate and result files. The -p option means mkdir will create the whole path if it does not exist (no error or message will be given if it does exist)
 
 ```bash
 $ mkdir -p results/sai
@@ -88,9 +88,9 @@ $ mkdir -p results/bcf
 $ mkdir -p results/vcf
 ```
 
-We will now use a loop to run the variant calling work flow of each of our fastq files, so the list of command below will be execute once for each fastq files.
+We will now use a loop to run the variant calling workflow of each of our fastq files, so the list of commands below will be executed once for each fastq file.
 
-We would start the loop like this, so the name of each fastq file will by assigned to $fq
+We will start the loop like this, so the name of each fastq file will by assigned to $fq
 
 ```bash
 $ for fq in data/trimmed_fastq/*.fastq


### PR DESCRIPTION
This pull request fixes typos in the three lessons for wrangling genomics.  This includes changes to the code in the trimmomatic section in lesson 0, specifically using "java -jar" instead of "java jar", fixing the parameter name from "threds" to "threads" and removing "-thr" in the generic command for trimmomatic.  

I'm submitting this as part of my instructor training.