### PR TITLE
Markdown syntax updates and typo fixes

### DIFF
--- a/00-readQC.md
+++ b/00-readQC.md
@@ -12,7 +12,7 @@ Learning Objectives:
 * Understand how the FastQ format encodes quality
 * Be able to evaluate a FastQC report
 * Use Trimmommatic to clean FastQ reads
-* Use a For loop to automate operations on multiple files
+* Use a `for` loop to automate operations on multiple files
 
 ## Bioinformatics workflows
 
@@ -89,7 +89,7 @@ As mentioned above, line 4 is a encoding of the quality. In this case, the code 
      (Note: See discussion above).
  L - Illumina 1.8+ Phred+33,  raw reads typically (0, 41)
  ```
- So using the Illumina 1.8 encoding, which is what you will mostly see from now on, our first c is called with a Phred score of 0 and our Ns are called with a score of 2. Read quality is assessed using the Phred Quality Score.  This score is logarithmically based and the score values can be interpreted as follows:
+ So using the Illumina 1.8 encoding, which is what you will mostly see from now on, our first C is called with a Phred score of 0 and our Ns are called with a score of 2. Read quality is assessed using the Phred Quality Score.  This score is logarithmically based and the score values can be interpreted as follows:
  
 |Phred Quality Score |Probability of incorrect base call |Base call accuracy|
 |:-------------------|:---------------------------------:|-----------------:|
@@ -109,7 +109,7 @@ CACTTGTAAGGGCAGGCCCCCTTCACCCTCCCGCTCCTGGGGGANNNNNNNNNNANNNCGAGGCCCTGGGGTAGAGGGNN
 @?@DDDDDDHHH?GH:?FCBGGB@C?DBEGIIIIAEF;FCGGI#########################################################
 ```
 
-As mentioned previously, line 4 has characters encoding the quality of each nucleotide in the read. The legend below provides the mapping of quality scores (Phred-33) to the quality encoding characters. ** *Different quality encoding scales exist (differing by offset in the ASCII table), but note the most commonly used one is fastqsanger* **
+As mentioned previously, line 4 has characters encoding the quality of each nucleotide in the read. The legend below provides the mapping of quality scores (Phred-33) to the quality encoding characters. ** *Different quality encoding scales exist (differing by offset in the ASCII table), but note the most commonly used one is fastqsanger.* **
 
  ```
  Quality encoding: !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHI
@@ -127,7 +127,7 @@ These probability values are the results from the base calling algorithm and dep
 
 
 ## FastQC
-FastQC (http://www.bioinformatics.babraham.ac.uk/projects/fastqc/) provides a simple way to do some quality control checks on raw sequence data coming from high throughput sequencing pipelines. It provides a modular set of analyses which you can use to give a quick impression of whether your data has any problems of which you should be aware before doing any further analysis.
+[FastQC](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/) provides a simple way to do some quality control checks on raw sequence data coming from high throughput sequencing pipelines. It provides a modular set of analyses which you can use to give a quick impression of whether your data has any problems of which you should be aware before doing any further analysis.
 
 The main functions of FastQC are:
 
@@ -148,9 +148,9 @@ Now let's take a look at a quality plot on the other end of the spectrum.
 
 ![bad_quality](./img/bad_quality.png)
 
-Here, we see positions within the read in which the boxes span a much wider range. Also, quality scores drop quite low into the 'bad' range, particularly on the tail end of the reads. When you encounter a quality plot such as this one, the first step is to troubleshoot. Why might we be seeing something like this? 
+Here, we see positions within the read in which the boxes span a much wider range. Also, quality scores drop quite low into the "bad" range, particularly on the tail end of the reads. When you encounter a quality plot such as this one, the first step is to troubleshoot. Why might we be seeing something like this? 
 
-The *FASTQC* tool produces several other diagnostic plots to assess sample quality, in addition to the one plotted above. 
+The FastQC tool produces several other diagnostic plots to assess sample quality, in addition to the one plotted above. 
 
 ## Running FASTQC
 ### A. Stage your data
@@ -170,21 +170,23 @@ The *FASTQC* tool produces several other diagnostic plots to assess sample quali
     mkdir dc_workshop/docs
     mkdir dc_workshop/results
     ``` 
-> The sample data we will be working with is in a hidden directory (placing a '.' in front of a directory name hides the directory. In the next step we will move some of those hidden files into our new dirctories to start our project.
+The sample data we will be working with is in a hidden directory (placing a '.' in front of a directory name hides the directory). In the next step we will move some of those hidden files into our new directories to start our project.
+
 3. Move our sample data to our working (home) directory
    
     ```bash
-$ mv ~/.dc_sampledata_lite/untrimmed_fastq/ ~/dc_workshop/data/
+    $ mv ~/.dc_sampledata_lite/untrimmed_fastq/ ~/dc_workshop/data/
     ```
 
-###B. Run FastQC
+### B. Run FastQC
 
 1. Navigate to the initial fastq dataset
    
     ```bash
     $ cd ~/dc_workshop/data/untrimmed_fastq/
     ```
-To run the fastqc program, we call it from its location in ``~/FastQC``.  fastqc will accept multiple file names as input, so we can use the *.fastq wildcard.
+    To run the fastqc program, we call it from its location in `~/FastQC`.  fastqc will accept multiple file names as input, so we can use the `*.fastq` wildcard.
+
 2. Run FastQC on all fastq files in the directory
 
     ```bash
@@ -198,71 +200,75 @@ To run the fastqc program, we call it from its location in ``~/FastQC``.  fastqc
 4. Next, move the files there (recall, we are still in ```~/dc_workshop/data/untrimmed_fastq/```)
     
     ```bash    
-$ mv *.zip ~/dc_workshop/results/fastqc_untrimmed_reads/
+    $ mv *.zip ~/dc_workshop/results/fastqc_untrimmed_reads/
     $ mv *.html ~/dc_workshop/results/fastqc_untrimmed_reads/
-```
+    ```
 
-###C. Results
+### C. Results
 
-Lets examine the results in detail
+Let's examine the results in detail:
 
 1. Navigate to the results and view the directory contents
 
-    ```
-$ cd ~/dc_workshop/results/fastqc_untrimmed_reads/
-$ ls
+    ```bash
+    $ cd ~/dc_workshop/results/fastqc_untrimmed_reads/
+    $ ls
     ``` 
-    > The zip files need to be unpacked with the 'unzip' program. 
+    The zip files need to be unpacked with the `unzip` program. 
 
-2. Use unzip to unzip the FastQC results: 
+2. Use `unzip` to unzip the FastQC results: 
 
+    ```bash
+    $ unzip *.zip
     ```
-$ unzip *.zip
-    ```
-Did it work? No, because 'unzip' expects to get only one zip file.  Welcome to the real world. We *could* do each file, one by one, but what if we have 500 files?  There is a smarter way. We can save time by using a simple shell 'for loop' to iterate through the list of files in *.zip. After you type the first line, you will get a special '>' prompt to type next next lines. You start with 'do', then enter your commands, then end with 'done' to execute the loop.
+    Did it work? No, because `unzip` expects to get only one zip file.  Welcome to the real world. We *could* do each file, one by one, but what if we have 500 files?  There is a smarter way. We can save time by using a simple shell `for` loop to iterate through the list of files in `*.zip`. After you type the first line, you will get a special `>` prompt to type next next lines. You start with `do`, then enter your commands, then end with `done` to execute the loop.
 
-3. Build a ``for`` loop to unzip the files
+3. Build a `for` loop to unzip the files
     
+    ```bash
+    $ for zip in *.zip
+    > do
+    > unzip $zip
+    > done
     ```
-$ for zip in *.zip
-> do
-> unzip $zip
-> done
+
+    Note that, in the first line, we create a variable named `zip`.  After that, we call that variable with the syntax `$zip`.  `$zip` is assigned the value of each item (file) in the list `*.zip`, once for each iteration of the loop.
+
+    This loop is basically a simple program.  When it runs, it will run `unzip` once for each file (whose name is stored in the `$zip` variable). The contents of each file will be unpacked into a separate directory by the `unzip` program.
+
+    The `for` loop is interpreted as a multipart command.  If you press the up arrow on your keyboard to recall the command, it will be shown like so:
+
+    ```bash
+    $ for zip in *.zip; do echo File $zip; unzip $zip; done
     ```
-Note that, in the first line, we create a variable named 'zip'.  After that, we call that variable with the syntax $zip.  $zip is assigned the value of each item (file) in the list *.zip, once for each iteration of the loop.
 
-This loop is basically a simple program.  When it runs, it will run unzip once for each file (whose name is stored in the $zip variable). The contents of each file will be unpacked into a separate directory by the unzip program.
-
-The for loop is interpreted as a multipart command.  If you press the up arrow on your keyboard to recall the command, it will be shown like so:
-   
-   ```
-$ for zip in *.zip; do echo File $zip; unzip $zip; done
-   ```
-When you check your history later, it will help your remember what you did!
+    When you check your history later, it will help your remember what you did!
 
 ### D. Document your work
 
-To save a record, let's cat all fastqc summary.txts into one full_report.txt and move this to ``~/dc_workshop/docs``. You can use wildcards in paths as well as file names.  Do you remember how we said 'cat' is really meant for concatenating text files?
+To save a record, let's `cat` all fastqc `summary.txt`s into one file `full_report.txt` and move this to ``~/dc_workshop/docs``. You can use wildcards in paths as well as file names.  Do you remember how we said `cat` is really meant for concatenating text files?
 
 ```bash    
 cat */summary.txt > ~/dc_workshop/docs/fastqc_summaries.txt
 ```
 
 
-##How to clean reads using *Trimmomatic*
-###A detailed explanation of features
+## How to clean reads using Trimmomatic
+### A detailed explanation of features
 
-Once we have an idea of the quality of our raw data, it is time to trim away adapters and filter out poor quality score reads. To accomplish this task we will use *Trimmomatic* [http://www.usadellab.org/cms/?page=trimmomatic](http://www.usadellab.org/cms/?page=trimmomatic).
+Once we have an idea of the quality of our raw data, it is time to trim away adapters and filter out poor quality score reads. To accomplish this task we will use [Trimmomatic](http://www.usadellab.org/cms/?page=trimmomatic).
 
-*Trimmomatic* is a java based program that can remove sequencer specific reads and nucleotides that fall below a certain threshold. *Trimmomatic* can be multithreaded to run quickly. 
+Trimmomatic is a java based program that can remove sequencer specific reads and nucleotides that fall below a certain threshold. Trimmomatic can be multithreaded to run quickly. 
 
-Because *Trimmomatic* is java based, it is run using the command:
+Because Trimmomatic is java based, it is run using the command:
 
-**_java jar trimmomatic-0.32.jar_**
+```
+java jar trimmomatic-0.32.jar
+```
 
-What follows this are the specific commands that tells the program exactly how you want it to operate. *Trimmomatic* has a variety of options and parameters:
+What follows this are the specific commands that tells the program exactly how you want it to operate. Trimmomatic has a variety of options and parameters:
 
-* **_-threds_** How many processors do you want *Trimmomatic* to run with?
+* **_-threads_** How many processors do you want Trimmomatic to run with?
 * **_SE_** or **_PE_** Single End or Paired End reads?
 * **_-phred33_** or **_-phred64_** Which quality score do your reads have?
 * **_SLIDINGWINDOW_** Perform sliding window trimming, cutting once the average quality within the window falls below a threshold.
@@ -274,15 +280,19 @@ What follows this are the specific commands that tells the program exactly how y
 * **_TOPHRED33_** Convert quality scores to Phred-33.
 * **_TOPHRED64_** Convert quality scores to Phred-64.
 
-A generic command for *Trimmomatic* looks like this:
+A generic command for Trimmomatic looks like this:
 
-**java jar trimmomatic-0.32.jar SE -thr**
+```
+java jar trimmomatic-0.32.jar SE -thr
+```
 
-A complete command for *Trimmomatic* will look something like this:
+A complete command for Trimmomatic will look something like this:
 
-**java jar trimmomatic-0.32.jar SE -threads 4 -phred64 SRR_1056.fastq SRR_1056_trimmed.fastq ILLUMINACLIP:SRR_adapters.fa SLIDINGWINDOW:4:20**
+```
+java jar trimmomatic-0.32.jar SE -threads 4 -phred64 SRR_1056.fastq SRR_1056_trimmed.fastq ILLUMINACLIP:SRR_adapters.fa SLIDINGWINDOW:4:20
+```
 
-This command tells *Trimmomatic* to run on a Single End file (``SRR_0156.fastq``, in this case), the output file will be called ``SRR_0156_trimmed.fastq``,  there is a file with Illumina adapters called ``SRR_adapters.fa``, and we are using a sliding window of size 4 that will remove those bases if their phred score is below 20.
+This command tells Trimmomatic to run on a Single End file (``SRR_0156.fastq``, in this case), the output file will be called ``SRR_0156_trimmed.fastq``,  there is a file with Illumina adapters called ``SRR_adapters.fa``, and we are using a sliding window of size 4 that will remove those bases if their phred score is below 20.
 
 
 ## Exercise - Running Trimmomatic
@@ -293,18 +303,18 @@ Go to the untrimmed fastq data location:
 $ cd /home/dcuser/dc_workshop/data/untrimmed_fastq
 ```
 
-The command line incantation for trimmomatic is more complicated.  This is where what you have been learning about accessing your command line history will start to become important.
+The command line incantation for Trimmomatic is more complicated.  This is where what you have been learning about accessing your command line history will start to become important.
 
 The general form of the command is:
 
    ```bash
 java -jar ~/Trimmomatic-0.32/trimmomatic-0.32.jar inputfile outputfile OPTION:VALUE...
 ```    
-'java -jar' calls the Java program, which is needed to run trimmomargumentstic, which lived in a 'jar' file (trimmomatic-0.32.jar), a special kind of java archive that is often used for programs written in the Java programing language.  If you see a new program that ends in '.jar', you will know it is a java program that is executed 'java -jar program name'.  The 'SE' argument is a keyword that specifies we are working with single-end reads.
+`java -jar` calls the Java program, which is needed to run Trimmomatic, which lived in a "jar" file (trimmomatic-0.32.jar), a special kind of java archive that is often used for programs written in the Java programing language.  If you see a new program that ends in `.jar`, you will know it is a java program that is executed `java -jar program name`.  The "SE" argument is a keyword that specifies we are working with single-end reads.
 
 The next two arguments are input file and output file names.  These are then followed by a series of options. The specifics of how options are passed to a program are different depending on the program. You will always have to read the manual of a new program to learn which way it expects its command-line arguments to be composed.
 
-So, for the single fastq input file 'SRR098283.fastq', the command would be:
+So, for the single fastq input file `SRR098283.fastq`, the command would be:
 
     $ java -jar /home/dcuser/Trimmomatic-0.32/trimmomatic-0.32.jar SE SRR098283.fastq \
     SRR098283.fastq_trim.fastq SLIDINGWINDOW:4:20 MINLEN:20
@@ -323,20 +333,20 @@ So that worked and we have a new fastq file.
     SRR098283.fastq  SRR098283.fastq_trim.fastq
 
 
-Now we know how to run trimmomatic but there is some good news and bad news.  
+Now we know how to run Trimmomatic but there is some good news and bad news.  
 One should always ask for the bad news first.  Trimmomatic only operates on 
 one input file at a time and we have more than one input file.  The good news?
-We already know how to use a for loop to deal with this situation.
+We already know how to use a `for` loop to deal with this situation.
 
 ```bash
     $ for infile in *.fastq
-    >do
-    >outfile=$infile\_trim.fastq
-    >java -jar ~/Trimmomatic-0.32/trimmomatic-0.32.jar SE $infile $outfile SLIDINGWINDOW:4:20 MINLEN:20
-    >done
+    > do
+    > outfile=$infile\_trim.fastq
+    > java -jar ~/Trimmomatic-0.32/trimmomatic-0.32.jar SE $infile $outfile SLIDINGWINDOW:4:20 MINLEN:20
+    > done
 ```
 
-Do you remember how the first specifies a variable that is assigned the value of each item in the list in turn?  We can call it whatever we like.  This time it is called infile.  Note that the third line of this for loop is creating a second variable called outfile.  We assign it the value of $infile with '_trim.fastq' appended to it.  The '\' escape character is used so the shell knows that whatever follows \ is not part of the variable name $infile.  There are no spaces before or after the '='.
+Do you remember how the first specifies a variable that is assigned the value of each item in the list in turn?  We can call it whatever we like.  This time it is called `infile`.  Note that the third line of this `for` loop is creating a second variable called `outfile`.  We assign it the value of `$infile` with `_trim.fastq` appended to it.  The escape character (`\`) is used so the shell knows that whatever follows `\` is not part of the variable name `$infile`.  There are no spaces before or after the `=`.
 
 
 


### PR DESCRIPTION
I've gone through this markdown document and fixed some markdown
problems. There were several areas where code blocks were messed up due
to indenting. I also tried to apply consistent use of code markups. I
fixed several small typos and standardized some spelling and text
formatting for phrases or names used throughout the document. I did not
(intentionally) change any content.

This PR goes beyond #12 but it may be worth merging both.

This PR is intended to fulfill my post-training lesson contribution. I also believe that @ErinBecker mentioned at our training that the genomics module is going to be overhauled - I'd be glad to participate in that when the time comes.