### PR TITLE
Install Instructions for setup.md

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -42,6 +42,33 @@ Trimmomatic is available for Linux, MacOS and Windows.
 
 Bwa is available for Linux and MacOS.
 
+#### Installation instructions:
+Reference: The Biostars Handbook
+
+```brew install bwa```
+or
+
+```conda install -y bwa```
+All other platforms:
+```
+cd ~/src
+curl -OL http://sourceforge.net/projects/bio-bwa/files/bwa-0.7.15.tar.bz2
+tar jxvf bwa-0.7.15.tar.bz2
+cd bwa-0.7.15
+make
+export PATH=~/src/bwa-0.7.15:$PATH
+```
+
+#### Test installation:
+
+Run:
+```
+bwa
+```
+BWA has a nicely formatted manual:
+
+```man ~/src/bwa-0.7.12/bwa.1 ```
+
 ### SAMtools
 
 [SAMtools](https://github.com/samtools/samtools) is a suite of programs for interacting with high-throughput sequencing data. Samtools can read/write/edit/index/view SAM/BAM/CRAM format.

--- a/setup.md
+++ b/setup.md
@@ -65,6 +65,41 @@ Test installation by running:
 
 Trimmomatic is available for Linux, MacOS and Windows.
 
+#### Installation Instructions:
+Reference: The Biostars Handbook
+
+```brew install trimmomatic```
+or
+```conda install -y trimmomatic```
+Installation from source
+```
+cd ~/src
+curl -O http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.36.zip
+unzip Trimmomatic-0.36.zip
+
+# The program can be invoked via
+java -jar ~/src/Trimmomatic-0.36/trimmomatic-0.36.jar
+
+# The ~/src/Trimmomatic-0.36/adapters/ directory contains
+# Illumina specific adapter sequences.
+ls ~/src/Trimmomatic-0.36/adapters/
+```
+#### How to run trimmomatic
+
+Unfortunately running trimmomatic is as user unfriendly as it gets. To run it we "simply" type:
+
+```java -jar ~/src/Trimmomatic-0.36/trimmomatic-0.36.jar```
+That gets old very quickly. To simplify the invocation create a script in the ~/bin folder:
+
+```
+echo '#!/bin/bash' > ~/bin/trimmomatic
+echo 'java -jar ~/src/Trimmomatic-0.36/trimmomatic-0.36.jar $@' >> ~/bin/trimmomatic
+chmod +x ~/bin/trimmomatic
+```
+Test installation by running:
+
+```trimmomatic```
+
 ### BWA
 
 [Bwa](https://github.com/lh3/bwa) is a software package for mapping DNA sequences against a large reference genome, such as the human genome.

--- a/setup.md
+++ b/setup.md
@@ -96,7 +96,7 @@ echo '#!/bin/bash' > ~/bin/trimmomatic
 echo 'java -jar ~/src/Trimmomatic-0.36/trimmomatic-0.36.jar $@' >> ~/bin/trimmomatic
 chmod +x ~/bin/trimmomatic
 ```
-Test installation by running:
+#### Test installation by running:
 
 ```trimmomatic```
 
@@ -162,7 +162,7 @@ make
 echo export `PATH=~/src/samtools-1.3:$PATH` >> ~/.bashrc
 source ~/.bashrc
 ```
-Test that the installation succeeded:
+#### Test that the installation succeeded:
 
 ```samtools```
 Samtools has a nicely formatted manual:
@@ -174,7 +174,19 @@ man ~/src/samtools-1.3/samtools.1
 
 [BCFtools](https://github.com/samtools/bcftools) is a program for variant calling and manipulating files in the Variant Call Format (VCF) and its binary counterpart BCF.
 
-BCFtools is available for Linuc and MacOS
+BCFtools is available for Linux and MacOS
+
+#### Installation Instructions
+Reference: The Biostars Handbook
+
+```brew install bcftools```
+or
+```
+conda install bcftools```
+
+#### Test that the installation succeeded:
+
+```bcftools```
 
 ### IGV
 

--- a/setup.md
+++ b/setup.md
@@ -177,12 +177,26 @@ man ~/src/samtools-1.3/samtools.1
 BCFtools is available for Linux and MacOS
 
 #### Installation Instructions
-Reference: The Biostars Handbook
 
 ```brew install bcftools```
 or
 ```
 conda install bcftools```
+
+#### Install from source
+
+```
+
+cd ~/src
+curl -OkL https://github.com/samtools/bcftools/releases/download/1.5/bcftools-1.5.tar.bz2
+tar jxvf bcftools-1.5.tar.bz2
+cd bcftools-1.5
+make
+
+# Add directory to the path if necessary
+echo export `PATH=~/src/bcftools-1.5:$PATH` >> ~/.bashrc
+source ~/.bashrc
+```
 
 #### Test that the installation succeeded:
 

--- a/setup.md
+++ b/setup.md
@@ -71,7 +71,7 @@ Reference: The Biostars Handbook
 ```brew install trimmomatic```
 or
 ```conda install -y trimmomatic```
-Installation from source
+#### Source Code Installation
 ```
 cd ~/src
 curl -O http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.36.zip
@@ -139,6 +139,36 @@ BWA has a nicely formatted manual:
 
 SAMtools is available for Linux and MacOS.
 
+#### Installation Instructions
+Reference: The Biostars Handbook
+
+```brew install samtools```
+or
+```conda install -y samtools```
+Note:
+Samtools has changed the command line invocation (for the better). But this means that most of the tutorials on the web indicate an older and obsolete usage.
+
+Use only samtools 1.3 or later.
+
+#### Source code installation
+```
+cd ~/src
+curl -OkL https://github.com/samtools/samtools/releases/download/1.3/samtools-1.3.tar.bz2
+tar jxvf samtools-1.3.tar.bz2
+cd samtools-1.3
+make
+
+# Add directory to the path if necessary
+echo export `PATH=~/src/samtools-1.3:$PATH` >> ~/.bashrc
+source ~/.bashrc
+```
+Test that the installation succeeded:
+
+```samtools```
+Samtools has a nicely formatted manual:
+```
+man ~/src/samtools-1.3/samtools.1 
+```
 
 ### bcftools
 

--- a/setup.md
+++ b/setup.md
@@ -4,7 +4,7 @@ title: Setup
 permalink: /setup/
 ---
 
-## Table of Content
+## Table of Contents
 
 * [Amazon Cloud](#amazon-cloud)
 * [Required software](#required-software)
@@ -18,9 +18,9 @@ permalink: /setup/
 
 ## Amazon Cloud
 
-Most of the genomics lessons from data carpentry currently use amazon cloud.
+Most of the genomics lessons from Data Carpentry currently use Amazon Cloud.
 
-We don't currently know if we'll keep using amazon cloud or not.
+We don't currently know if we'll keep using Amazon Cloud or not.
 
 ## Required software
 
@@ -113,7 +113,8 @@ Reference: The Biostars Handbook
 or
 
 ```conda install -y bwa```
-All other platforms:
+
+##### Installation from source:
 ```
 cd ~/src
 curl -OL http://sourceforge.net/projects/bio-bwa/files/bwa-0.7.15.tar.bz2
@@ -135,7 +136,7 @@ BWA has a nicely formatted manual:
 
 ### SAMtools
 
-[SAMtools](https://github.com/samtools/samtools) is a suite of programs for interacting with high-throughput sequencing data. Samtools can read/write/edit/index/view SAM/BAM/CRAM format.
+[SAMtools](https://github.com/samtools/samtools) is a suite of programs for interacting with high-throughput sequencing data. SAMtools can read/write/edit/index/view SAM/BAM/CRAM format.
 
 SAMtools is available for Linux and MacOS.
 
@@ -146,9 +147,9 @@ Reference: The Biostars Handbook
 or
 ```conda install -y samtools```
 Note:
-Samtools has changed the command line invocation (for the better). But this means that most of the tutorials on the web indicate an older and obsolete usage.
+SAMtools has changed the command line invocation (for the better). But this means that most of the tutorials on the web indicate an older and obsolete usage.
 
-Use only samtools 1.3 or later.
+Use only SAMtools 1.3 or later.
 
 #### Source code installation
 ```
@@ -165,12 +166,12 @@ source ~/.bashrc
 #### Test that the installation succeeded:
 
 ```samtools```
-Samtools has a nicely formatted manual:
+SAMtools has a nicely formatted manual:
 ```
 man ~/src/samtools-1.3/samtools.1 
 ```
 
-### bcftools
+### BCFtools
 
 [BCFtools](https://github.com/samtools/bcftools) is a program for variant calling and manipulating files in the Variant Call Format (VCF) and its binary counterpart BCF.
 
@@ -186,7 +187,6 @@ conda install bcftools```
 #### Install from source
 
 ```
-
 cd ~/src
 curl -OkL https://github.com/samtools/bcftools/releases/download/1.5/bcftools-1.5.tar.bz2
 tar jxvf bcftools-1.5.tar.bz2

--- a/setup.md
+++ b/setup.md
@@ -30,6 +30,35 @@ We don't currently know if we'll keep using amazon cloud or not.
 
 FastQC is available for Linux, MacOS and Windows.
 
+#### Install Instructions:
+Reference: The Biostars Handbook
+
+```brew install fastqc```
+or
+
+```conda install -y fastqc```
+
+#### Source code installation
+
+This is helpful when one wants to understand what type of files come with fastqc
+````
+cd ~/src
+curl -O http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip
+unzip fastqc_v0.11.5.zip
+
+# Link the fastqc executable to the ~/bin folder that
+# you have already added to the path.
+ln -sf ~/src/FastQC/fastqc ~/bin/fastqc
+
+# Due to what seems a packaging error
+# the executable flag on the fastqc program is not set.
+# We need to set it ourselves.
+chmod +x ~/bin/fastqc
+```
+Test installation by running:
+
+```fastqc -h```
+
 ### Trimmomatic
 
 [Trimmomatic](http://www.usadellab.org/cms/?page=trimmomatic) is a java based program that can remove sequencer specific reads and nucleotides that fall below a certain threshold. Trimmomatic can be multithreaded to run quickly.


### PR DESCRIPTION
Added install instructions for FASTQC, Trimmomatic, SAMtools, bwa, and bcftools.  Also corrected small spelling errors and inconsistencies.  Instructions references are from The Biostars Handbook, which I followed to install on my own machine.