### PR TITLE
update contribution info

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ It builds on the work of [Software Carpentry](http://software-carpentry.org/) an
 
 ## Contribution
 
-There are many ways of contributing to Library Carpentry:
-
-- Join our [![Gitter chat](https://badges.gitter.im/datacarpentry/wrangling-genomics.png)](https://gitter.im/wrangling-genomics/Lobby)
-- Follow updates on our *soon to be active* [Twitter](https://twitter.com/WranglingGenomics).
 - Make a suggestion or correct an error by [raising an Issue](https://github.com/datacarpentry/wrangling-genomics/issues).
 
 ## Code of Conduct


### PR DESCRIPTION
The twitter and gitter info appear to have been copied over from a Library Carpentry lesson. There is a gitter room, but no activity, and no corresponding Twitter account. I've removed links to both of those and removed the reference to Library Carpentry.

Fixes https://github.com/datacarpentry/wrangling-genomics/issues/43