### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wrangling Genomics
 
-Lesson for quality control and wrangling genomics data. This repository is maintained by [Luis Avila](https://github.com/lmavila), and [Niel Infante](https://github.com/NielInfante). 
+Lesson for quality control and wrangling genomics data. This repository is maintained by [Josh Herr](https://github.com/jrherr), [Ming Tang](https://github.com/crazyhottommy), [Lex Nederbragt](https://github.com/lexnederbragt), and [Fotis Psomopoulos](https://github.com/fpsom).
 
 Amazon public AMI for this tutorial is "dataCgen-qc". 
 
@@ -8,8 +8,7 @@ Amazon public AMI for this tutorial is "dataCgen-qc".
 
 Wrangling genomics trains novice learners on a variant calling workflow. Participants will learn how to evaluate sequence quality and what to do if it is not good. We will then cover aligning reads to a genome, and calling variants, as well as discussing different file formats. Results will be visualized. Finally, we will cover how to automate the process by building a shell script.
 
-It builds on the work of [Software Carpentry](http://software-carpentry.org/) and [Data Carpentry](http://www.datacarpentry.org/).
-
+This lesson is part of the [Data Carpentry](http://www.datacarpentry.org/) [Genomics Workshop](http://www.datacarpentry.org/genomics-workshop/).
 
 ## Contribution
 
@@ -17,7 +16,7 @@ It builds on the work of [Software Carpentry](http://software-carpentry.org/) an
 
 ## Code of Conduct
 
-All participants should agree to abide by the [Software Carpentry Code of Conduct](http://software-carpentry.org/conduct/).
+All participants should agree to abide by the [Data Carpentry Code of Conduct](http://www.datacarpentry.org/code-of-conduct/).
 
 ## Authors
 


### PR DESCRIPTION
Updated maintainer information and links to Data Carpentry rather than Software Carpentry. Addresses README section of https://github.com/datacarpentry/wrangling-genomics/issues/22. 