### PR TITLE
Delete AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,0 @@
-FIXME: list authors' names and email addresses.


### PR DESCRIPTION
Complete author information will be auto-generated during publication. Since all contributors are considered authors, this file is redundant.