### PR TITLE
Clean up trimming episode

### DIFF
--- a/_episodes/01-trimming.md
+++ b/_episodes/01-trimming.md
@@ -3,93 +3,125 @@ title: "Trimming and Filtering"
 teaching: 0
 exercises: 0
 questions:
-- "Is my data good enough?"
+- "How can I get rid of sequence data that doesn't meet my quality standards?"
 objectives:
 - "Clean FASTQ reads using Trimmommatic."
-- "Employ `for` loops to automate operations on multiple files."
 keypoints:
 - "First key point."
 ---
 
-# How to clean reads using Trimmomatic
+# Cleaning Reads
 
-Some text here
+In the previous episode, we took a high-level look at the quality
+of each of our samples using FastQC. We vizualized per-base quality
+graphs showing the distribution of read quality at each base across
+all reads in a sample and extracted information about which samples 
+fail which quality checks. We know that all of our samples failed at 
+least one of the quality metrics used by FastQC. This doesn't mean, 
+though, that our samples should be thrown out! It's very common to
+have some reads within a sample,
+or some positions (near the begining or end of reads) across all
+reads that are low
+quality and should be discarded. We will use a program called 
+[Trimmomatic](http://www.usadellab.org/cms/?page=trimmomatic) to 
+filter poor quality reads and trim poor quality bases from our samples.
 
-## A. detailed explanation of features
+## Trimmomatic Options
 
-Once we have an idea of the quality of our raw data, it is time to trim away adapters and filter out poor quality score reads. To accomplish this task we will use [Trimmomatic](http://www.usadellab.org/cms/?page=trimmomatic).
-
-Trimmomatic is a java based program that can remove sequencer specific reads and nucleotides that fall below a certain threshold. Trimmomatic can be multithreaded to run quickly. 
-
-Because Trimmomatic is java based, it is run using the command:
+Trimmomatic is a program written in the Java programming language.
+You don't need to learn Java to use Trimmomatic (FastQC is also 
+written in Java), but the fact that it's a Java program helps 
+explain the syntax that is used to run Trimmomatic. The basic
+command to run Trimmomatic starts like this:
 
 ~~~
-$ java jar trimmomatic-0.32.jar
+$ java -jar trimmomatic-0.32.jar
 ~~~
 {: .bash}
 
-What follows this are the specific commands that tells the program exactly how you want it to operate. Trimmomatic has a variety of options and parameters:
+`java` tells our computer that we're running a Java program. `-jar`
+is an option specifying that we're going to specify the location of
+the Java program we want to run. The Java program itself will have
+a `.jar` file extension.
 
-* `-threads` How many processors do you want *Trimmomatic* to run with?
-* `SE` or `PE` Single End or Paired End reads?
-* `-phred33` or `-phred64` Which quality score do your reads have?
-* `SLIDINGWINDOW` Perform sliding window trimming, cutting once the average quality within the window falls below a threshold.
-* `LEADING` Cut bases off the start of a read, if below a threshold quality.
-* `TRAILING` Cut bases off the end of a read, if below a threshold quality.
-* `CROP` Cut the read to a specified length.
-* `HEADCROP` Cut the specified number of bases from the start of the read.
-* `MINLEN` Drop an entire read if it is below a specified length.
-* `TOPHRED33` Convert quality scores to Phred-33.
-* `TOPHRED64` Convert quality scores to Phred-64.
+That's just the basic command, however. Trimmomatic has a variety of
+options and parameters. We will need to specify what options we want
+to use for our analysis. Here are some of the options: 
 
-A generic command for Trimmomatic looks like this:
+
+| option    | meaning |
+| ------- | ---------- |
+| `-threads` | Specify the number of processors you want Trimmomatic to use. |
+|  `SE` or `PE`   | Specify whether your reads are single or paired end. |
+|  `-phred33` or `-phred64` | Specify the encoding system for your quality scores. |
+
+In addition to these options, there are various trimming steps 
+available:
+
+| step   | meaning |
+| ------- | ---------- |
+| `SLIDINGWINDOW` | Perform sliding window trimming, cutting once the average quality within the window falls below a threshold. |  
+| `LEADING`  | Cut bases off the start of a read, if below a threshold quality.  | 
+|  `TRAILING` |  Cut bases off the end of a read, if below a threshold quality. | 
+| `CROP`  |  Cut the read to a specified length. | 
+|  `HEADCROP` |  Cut the specified number of bases from the start of the read. | 
+| `MINLEN`  |  Drop an entire read if it is below a specified length. | 
+|  `TOPHRED33` | Convert quality scores to Phred-33.  | 
+|  `TOPHRED64` |  Convert quality scores to Phred-64. | 
+
+We will use only a few of these options and trimming steps in our
+analysis. It is important to understand the steps you are using to 
+clean your data. For more information about the Trimmomatic arguments 
+and options, see [the Trimmomatic manual](http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/TrimmomaticManual_V0.32.pdf).
+
+We said above that a basic command for Trimmomatic looks like this:
 
 ~~~
 $ java -jar trimmomatic-0.32.jar SE
 ~~~
 {: .bash}
 
-A complete command for Trimmomatic will look something like this:
+However, a complete command for Trimmomatic will look something like this:
 
 ~~~
 java -jar trimmomatic-0.32.jar SE -threads 4 -phred64 SRR_1056.fastq SRR_1056_trimmed.fastq ILLUMINACLIP:SRR_adapters.fa SLIDINGWINDOW:4:20
 ~~~
 {: .bash}
 
-This command tells Trimmomatic to run on a Single End file (``SRR_0156.fastq``, in this case), the output file will be called ``SRR_0156_trimmed.fastq``,  there is a file with Illumina adapters called ``SRR_adapters.fa``, and we are using a sliding window of size 4 that will remove those bases if their phred score is below 20.
+In this example, we've told Trimmomatic:
 
-## Exercise - Running Trimmomatic
+| code   | meaning |
+| ------- | ---------- |
+| `SE` | that it will be taking a single end file as input |
+| `-threads 4` | to use four computing threads to run (this will spead up our run) |
+| `-phred64` | that the input file uses phred-64 encoding for quality scores |
+| `SRR_1056.fastq` | the input file name |
+|  `SRR_1056_trimmed.fastq` | the output file to create |
+| `ILLUMINACLIP:SRR_adapters.fa`| to clip the Illumina adapters from the input file using the adapter sequences listed in `SRR_adapters.fa` |
+|`SLIDINGWINDOW:4:20` | to use a sliding window of size 4 that will remove bases if their phred score is below 20 |
 
-To begin, go to the untrimmed fastq data location:
+## Running Trimmomatic
+
+Now we will run Trimmomatic on our data. To begin, navigate to your `untrimmed_fastq` data directory:
 
 ~~~
-$ cd /home/dcuser/dc_workshop/data/untrimmed_fastq
+$ cd ~/dc_workshop/data/untrimmed_fastq
+~~~
+{: .bash}
+
+We are going to run Trimmomatic on one of our single-end samples. We 
+will use a sliding window of size 4 that will remove bases if their
+phred score is below 20 (like in our example above). We will also
+discard any reads that do not have at least 20 bases remaining after
+this trimming step.
+
+~~~
+$ java -jar ~/Trimmomatic-0.32/trimmomatic-0.32.jar SE SRR098283.fastq SRR098283.fastq_trim.fastq SLIDINGWINDOW:4:20 MINLEN:20
 ~~~
 {: .bash}
 
-The command line incantation for Trimmomatic is more complicated.  This is where what you have been learning about accessing your command line history will start to become important.
-
-The general form of the command is:
-
-~~~
-$ java -jar ~/Trimmomatic-0.32/trimmomatic-0.32.jar inputfile outputfile OPTION:VALUE...
-~~~
-{: .bash}
-
-`java -jar` calls the Java program, which is needed to run Trimmomatic, which lived in a "jar" file (trimmomatic-0.32.jar), a special kind of java archive that is often used for programs
-written in the Java programing language.  If you see a new program that ends in `.jar`, you will know it is a java program that is executed `java -jar program name`.  The "SE" argument is a 
-keyword that specifies we are working with single-end reads.
-
-The next two arguments are input file and output file names.  These are then followed by a series of options. The specifics of how options are passed to a program are different depending on the 
-program. You will always have to read the manual of a new program to learn which way it expects its command-line arguments to be composed.
-
-So, for the single fastq input file `SRR098283.fastq`, the command would be:  
-
-~~~
-$ java -jar /home/dcuser/Trimmomatic-0.32/trimmomatic-0.32.jar SE SRR098283.fastq \
-SRR098283.fastq_trim.fastq SLIDINGWINDOW:4:20 MINLEN:20
-~~~
-{: .bash}
+Notice that we needed to give the absolute path to our copy of the
+Trimmomatic program.
 
 ~~~
 TrimmomaticSE: Started with arguments: SRR098283.fastq SRR098283.fastq_trim.fastq SLIDINGWINDOW:4:20 MINLEN:20
@@ -100,7 +132,25 @@ TrimmomaticSE: Completed successfully
 ~~~
 {: .output}
 
-So that worked and we have a new fastq file.
+> ## Exercise
+> 
+> Use the output from your Trimmomatic command to answer the
+> following questions. 
+> 
+> 1) What percent of reads did we discard from our sample?  
+> 2) What percent of reads did we keep? 
+> 
+>> ## Solution
+>> 1) 21.02%  
+>> 2) 78.98%
+> {: .solution}
+{: .challenge}
+
+You may have noticed that Trimmomatic automatically detected the 
+quality encoding of our sample. It is always a good idea to 
+double-check this or to enter the quality encoding manually.
+
+We can confirm that we have our output file: 
 
 ~~~
 $ ls SRR098283*
@@ -112,10 +162,26 @@ SRR098283.fastq  SRR098283.fastq_trim.fastq
 ~~~
 {: .output}
 
-Now we know how to run Trimmomatic but there is some good news and bad news.  
-One should always ask for the bad news first.  Trimmomatic only operates on 
-one input file at a time and we have more than one input file.  The good news?
-We already know how to use a `for` loop to deal with this situation.
+The output file is also a FASTQ file. It should be smaller than our
+input file because we've removed reads. We can confirm this:
+
+~~~
+$ ls SRR098283* -l -h
+~~~
+{: .bash}
+
+~~~
+-rw-r--r-- 1 dcuser dcuser 3.9G Jul 30  2015 SRR098283.fastq
+-rw-rw-r-- 1 dcuser dcuser 3.0G Nov  7 23:10 SRR098283.fastq_trim.fastq
+~~~
+{: .output}
+
+
+We've just successfully run Trimmomatic on one of our FASTQ files!
+However, there is some bad news. Trimmomatic can only operate on 
+one sample at a time and we have more than one sample. The good news
+is that we can use a `for` loop to iterate through our sample files
+quickly!
 
 ~~~
 $ for infile in *.fastq
@@ -126,6 +192,102 @@ $ for infile in *.fastq
 ~~~
 {: .bash}
 
-Do you remember how the first specifies a variable that is assigned the value of each item in the list in turn?  We can call it whatever we like.  This time it is called `infile`. 
-Note that the third line of this `for` loop is creating a second variable called `outfile`.  We assign it the value of `$infile` with `_trim.fastq` appended to it.
-The `\` escape character is used so the shell knows that whatever follows `\` is not part of the variable name `$infile`.  There are no spaces before or after the `=`.
+The new part in our `for` loop is the line: 
+
+~~~
+> outfile=$infile\_trim.fastq
+~~~
+{: .bash}
+
+`infile` is the first variable in our loop and takes the value
+of each of the FASTQ files in our directory. `outfile` is the 
+second variable in our loop and is defined by adding `_trim.fastq` to 
+the end of our input file name. The `\` escape character is used so
+the shell knows that whatever follows `\` is not part of the variable 
+name `$infile`.  There are no spaces before or after the `=`.
+
+Go ahead and run the for loop. It should take a few minutes for 
+Trimmomatic to run for each of our six input files. Once it's done
+running, take a look at your directory contents.
+
+~~~
+$ ls 
+~~~
+{: .bash}
+
+~~~
+SRR097977.fastq		    SRR098027.fastq_trim.fastq	SRR098283.fastq
+SRR097977.fastq_trim.fastq  SRR098028.fastq		SRR098283.fastq_trim.fastq
+SRR098026.fastq		    SRR098028.fastq_trim.fastq	SRR098283.fastq_trim.fastq_trim.fastq
+SRR098026.fastq_trim.fastq  SRR098281.fastq
+SRR098027.fastq		    SRR098281.fastq_trim.fastq
+~~~
+{: .output}
+
+If you look very closely, you'll see that you have three files for the
+`SRR098283` sample. This is because we already had the `SRR098283.fastq_trim.fastq` file in our directory when we started
+our `for` loop (because we had run Trimmomatic on just that one file already). 
+Our `for` loop included this file in our list of `.fastq` files and 
+created a new output file named `SRR098283.fastq_trim.fastq_trim.fastq`, which is the result of 
+running Trimmomatic on our already trimmed file. `SRR098283.fastq_trim.fastq` and `SRR098283.fastq_trim.fastq_trim.fastq` should be identical. If you look at your Trimmomatic output in the terminal window, you will see:
+
+~~~
+TrimmomaticSE: Started with arguments: SRR098283.fastq_trim.fastq SRR098283.fastq_trim.fastq_trim.fastq SLIDINGWINDOW:4:20 MINLEN:20
+Automatically using 2 threads
+Quality encoding detected as phred33
+Input Reads: 17030985 Surviving: 17030985 (100.00%) Dropped: 0 (0.00%)
+TrimmomaticSE: Completed successfully
+~~~
+{: .output}
+
+This shows that when we re-trimmed our trimmed file, no new reads were 
+dropped. This is a good thing!
+
+> ## Exercise
+> Earlier we looked at the first read in our `SRR098281.fastq` file and
+> saw that it was very poor quality. 
+> 
+> ~~~
+> $ head -n4 SRR098281.fastq
+> ~~~
+> {: .bash}
+> 
+> ~~~
+> @SRR098281.1 HWUSI-EAS1599_1:2:1:0:318 length=35
+> CNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+> +SRR098281.1 HWUSI-EAS1599_1:2:1:0:318 length=35
+> #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+> ~~~
+> {: .output}
+>
+> After filtering out bad reads, what is the first remaining read for
+> this sample? What does its quality look like?
+>
+>> ## Solution
+>> ~~~
+>> $ head -n4 SRR098281.fastq_trim.fastq
+>> ~~~
+>> {: .bash}
+>> 
+>> ~~~
+>> @SRR098281.256 HWUSI-EAS1599_1:2:1:1:315 length=35
+>> CTGGTGGTACTNTCTGTGGCG
+>> +SRR098281.256 HWUSI-EAS1599_1:2:1:1:315 length=35
+>> BA@A;?==B>=!BABA=3@AA
+>> ~~~
+>> {: .output}
+>>
+>> Comparing this with our quality scale: 
+>> 
+>> ~~~
+>> Quality encoding: !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHI
+>>                   |         |         |         |         |
+>> Quality score:    0........10........20........30........40                                
+>> ~~~
+>> {: .output}
+>> 
+>> We can see that the scores are mostly in the 30+ range. This is 
+>> pretty good. 
+> {: .solution}
+{: .challenge}
+


### PR DESCRIPTION
This PR: 

1) Removes redundancy in the trimming episode about generic vs specific Trimmomatic calls.
2) Adds expected output for all commands. 
3) Adds two exercises and solutions (there were no exercises for this episode).
4) Formats Trimmomatic options in tables rather than bulleted list for readability.