### PR TITLE
Update setup.md - Issues with Mac installs and a minor edit

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -31,7 +31,7 @@ We don't currently know if we'll keep using Amazon Cloud or not.
 FastQC is available for Linux, MacOS and Windows.
 
 #### Install Instructions:
-Reference: The Biostars Handbook
+Reference: [The Biostars Handbook](https://www.biostarhandbook.com/)
 
 ```brew install fastqc```
 or


### PR DESCRIPTION
I added the link for The Biostars Handbook. 

Also I followed along with the instructions on a Mac instead of an Amazon instance, since all of the packages indicated they are available for Mac. This went fine except for BCFtools, which failed to compile. I didn't chase the problem, but I'm guessing a missing library:

```
cd htslib-1.5 && /Library/Developer/CommandLineTools/usr/bin/make lib-static
gcc -g -Wall -O2 -I.  -c -o cram/cram_io.o cram/cram_io.c
cram/cram_io.c:60:10: fatal error: 'lzma.h' file not found
#include <lzma.h>
         ^~~~~~~~
1 error generated.
make[1]: *** [cram/cram_io.o] Error 1
make: *** [htslib-1.5/libhts.a] Error 2

```

I then tried installing homebrew and miniconda to see if they could successfully install BCFtools. Homebrew failed to install based on the command provided at https://brew.sh/. The miniconda install was successful, but then was unable to install BCFtools because it couldn't find BCFtools in the channels it searched: 

```
PackageNotFoundError: Packages missing in current channels:
            
  - bcftools

We have searched for the packages in the following channels:
            
  - https://repo.continuum.io/pkgs/main/osx-64
  - https://repo.continuum.io/pkgs/main/noarch
  - https://repo.continuum.io/pkgs/free/osx-64
  - https://repo.continuum.io/pkgs/free/noarch
  - https://repo.continuum.io/pkgs/r/osx-64
  - https://repo.continuum.io/pkgs/r/noarch
  - https://repo.continuum.io/pkgs/pro/osx-64
  - https://repo.continuum.io/pkgs/pro/noarch
```

Considering that Carpentry lessons are expected to run on all three platforms, it seems like the instructions need updating and testing on Mac and PC as well.

I should note I'm running on Mac OS 10.12.6.