### PR TITLE
Minor typo fixes

### DIFF
--- a/_episodes/02-variant_calling.md
+++ b/_episodes/02-variant_calling.md
@@ -122,7 +122,7 @@ parameters here, your use case might require a change of parameters. *NOTE: Alwa
 and make sure the options you use are appropriate for your data.*
 
 We're going to start by aligning the reads from just one of the 
-samples in our dataset (`SRR098283.fastq`). Later, we'll be 
+samples in our dataset (`SRR097977.fastq`). Later, we'll be 
 iterating this whole process on all of our sample files.
 
 ~~~

--- a/_episodes/03-automation.md
+++ b/_episodes/03-automation.md
@@ -7,7 +7,6 @@ questions:
 objectives:
 - "Write a shell script with multiple variables."
 - "Incorporate a `for` loop into a shell script."
-- ""
 keypoints:
 - "We can combine multiple commands into a shell script to automate a workflow."
 - "Use `echo` statements within your scripts to get an automated progress update."


### PR DESCRIPTION
Fixes for some very minor typos I found while prepping for this lesson!

- In the Variant Calling lesson, the text specifies that we'll be using one fastq file (`SRR098023.fastq`) but the remainder of the lesson uses another instead (`SRR097977.fastq`). 
- The Automation lesson objectives include a stray bullet point. 