### PR TITLE
update link from osf to figshare

### DIFF
--- a/_episodes/04-variant_calling.md
+++ b/_episodes/04-variant_calling.md
@@ -64,8 +64,7 @@ We will also download a set of trimmed FASTQ files to work with. These are small
 and will enable us to run our variant calling workflow quite quickly. 
 
 ~~~
-# This is a place holder so the workflow will work. This will be updated with figshare links later
-$ curl -L -o sub.tar.gz https://osf.io/gbt7p/download
+$ curl -L -o sub.tar.gz https://ndownloader.figshare.com/files/14418248
 $ tar xvf sub.tar.gz
 $ mv sub/ ~/dc_workshop/data/trimmed_fastq_small
 ~~~

--- a/files/download-links-for-files.txt
+++ b/files/download-links-for-files.txt
@@ -11,4 +11,4 @@ ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/006/SRR2584866/SRR2584866_1.fastq.gz
 ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/006/SRR2584866/SRR2584866_2.fastq.gz 
 
 # subsampled fastq:
-https://osf.io/ckf6w/download
+https://ndownloader.figshare.com/files/14418248

--- a/files/subsample-trimmed-fastq.txt
+++ b/files/subsample-trimmed-fastq.txt
@@ -1,5 +1,5 @@
 # sumbsampled fastq files were made with the following code.
-# The sample are available for download here: https://osf.io/ckf6w/download
+# The sample are available for download here: https://ndownloader.figshare.com/files/14418248
 
 mkdir -p ~/dc_workshop/data/untrimmed_fastq/
 cd ~/dc_workshop/data/untrimmed_fastq


### PR DESCRIPTION
@taylorreiter - I've replaced all of the instances where the lesson refers to the OSF dataset with the newly published dataset on FigShare (https://ndownloader.figshare.com/files/14418248). Please let me know if I've missed anything or if any of these changes are incorrect!