### PR TITLE
Update FastQC call in `read_qc.sh`

### DIFF
--- a/_episodes/05-automation.md
+++ b/_episodes/05-automation.md
@@ -115,7 +115,7 @@ on all of the files in our current directory with a `.fastq` extension.
 
 ~~~
 echo "Running FastQC ..."
-~/FastQC/fastqc *.fastq
+fastqc *.fastq*
 ~~~
 {: .output}
 
@@ -181,7 +181,7 @@ set -e
 cd ~/dc_workshop/data/untrimmed_fastq/
 
 echo "Running FastQC ..."
-~/FastQC/fastqc *.fastq
+fastqc *.fastq*
 
 mkdir -p ~/dc_workshop/results/fastqc_untrimmed_reads
 


### PR DESCRIPTION
For the AWS instances that were set up for an upcoming workshop (2019-03-21-csumb) the original command didn't work. There is no `~/FastQC` directory and the call to just `fastqc` works, and matches calls to `fastqc` in earlier lessons.
Adding the extra wildcard to make `*.fastq*` allows both gzipped and unzipped files to be run. (Mine were all gzipped after following the lessons without deviating).