### PR TITLE
Add comma in compound sentence

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ A lot of genomics analysis is done using command-line tools for three reasons:
 through a graphical user interface (GUI) allows you to automate repetitive tasks,    
 2) you will often need more compute power than is available on your personal computer, and 
 connecting to and interacting with remote computers requires a command-line interface, and    
-3) you will often need to customize your analyses and command-line tools often enable more 
+3) you will often need to customize your analyses, and command-line tools often enable more 
 customization than the corresponding GUI tools (if in fact a GUI tool even exists).   
 
 In a [previous lesson](http://www.datacarpentry.org/shell-genomics/), you learned how to use the bash shell to interact with your computer through a command line interface. In this 


### PR DESCRIPTION
I tripped over this sentence while reading it: "3) you will often need to customize your analyses and command-line tools often enable". I had to re-read it a few times before I realized that the "and" is the start of a new sentence. I am proposing a comma before the "and" because I think the comma increases readability.

After a bit of digging, I think I have figured out the source of my confusion. Sentence 3) is a compound sentence bound together by "and", and such sentences take a comma before the "and". Incidentally, the previous sentence is a compound sentence too. For reference, see rule #3 [here](https://webapps.towson.edu/ows/modulecomma.htm)

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
