### PR TITLE
Correction of typos/errors in wrangling materials

### DIFF
--- a/_episodes/02-quality-control.md
+++ b/_episodes/02-quality-control.md
@@ -620,7 +620,7 @@ us whether this sample passed, failed, or is borderline (`WARN`). Remember to qu
 
 We can make a record of the results we obtained for all our samples
 by concatenating all of our `summary.txt` files into a single file 
-using the `cat` command. We'll call this `full_report.txt` and move
+using the `cat` command. We'll call this `fastqc_summaries.txt` and move
 it to `~/dc_workshop/docs`.
 
 ~~~

--- a/_episodes/03-trimming.md
+++ b/_episodes/03-trimming.md
@@ -95,7 +95,7 @@ In this example, we've told Trimmomatic:
 
 | code   | meaning |
 | ------- | ---------- |
-| `PE` | that it will be taking a single end file as input |
+| `PE` | that it will be taking a paired end file as input |
 | `-threads 4` | to use four computing threads to run (this will spead up our run) |
 | `SRR_1056_1.fastq` | the first input file name |
 | `SRR_1056_2.fastq` | the second input file name |

--- a/_episodes/04-variant_calling.md
+++ b/_episodes/04-variant_calling.md
@@ -451,7 +451,7 @@ Below the horizontal line, we can see all of the reads in our sample aligned wit
 positions where the called base differs from the reference are shown. You can use the arrow keys on your keyboard
 to scroll or type `?` for a help menu. To navigate to a specific position, type `g`. A dialogue box will appear. In
 this box, type the name of the "chromosome" followed by a colon and the position of the variant you would like to view
-(e.g. for this sample, type `CP000819.1:50` to view the 50th base. Type `Ctrl^C` or `q` to exit `tview`. 
+(e.g. for this sample, type `NC_012967.1:50` to view the 50th base. Type `Ctrl^C` or `q` to exit `tview`. 
 
 > ## Exercise 
 > 
@@ -465,7 +465,7 @@ this box, type the name of the "chromosome" followed by a colon and the position
 >> ~~~
 >> {: .bash}
 >> 
->> Then type `g`. In the dialogue box, type `CP000819.1:4377265`. 
+>> Then type `g`. In the dialogue box, type `NC_012967.1:4377265`. 
 >> `G` is the variant. `A` is canonical. This variant possibly changes the phenotype of this sample to hypermutable. It occurs
 >> in the gene *mutL*, which controls DNA mismatch repair.
 > {: .solution}


### PR DESCRIPTION
Hi - did a thorough run-through of material as would like to run a Genomic Data Carpentry session.
This process identified the following issues:
1) Ambiguity in name used in text for aggregated fasted summaries and name used in code
2) Error in explanation of Trimmomatic command attributing PE code to single ended data
3) Error in View exercise regarding co-ordinates (wrong genome)

HTH,
Mark Fernandes
Software & Data Carpentry Instructor (CRUK Cambridge Institute)