### PR TITLE
Added prompt to command that didn't have one

### DIFF
--- a/_episodes/02-quality-control.md
+++ b/_episodes/02-quality-control.md
@@ -65,7 +65,7 @@ curl -O ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR258/006/SRR2584866/SRR2584866_2.fa
 > avoid needing to download the data and instead use the data files provided in the `.backup/` directory.
 > 
 > ~~~
-> cp ~/.backup/untrimmed_fastq/*fastq.gz .
+> $ cp ~/.backup/untrimmed_fastq/*fastq.gz .
 > ~~~
 > {: .bash}
 > 


### PR DESCRIPTION
Added a prompt to the one command that didn't have one in this lesson - it confused one of our learners because it wasn't in the first command but was in the second, so they ended up trying to type the prompt for the second command.
