### PR TITLE
making quality coding consistent with reads

### DIFF
--- a/_episodes/02-quality-control.md
+++ b/_episodes/02-quality-control.md
@@ -133,7 +133,7 @@ uses the standard Sanger quality PHRED score encoding, using Illumina version 1.
 Each character is assigned a quality score between 0 and 40 as shown in the chart below.
 
 ~~~
-Quality encoding: !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHI
+Quality encoding: @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefgh
                   |         |         |         |         |
 Quality score:    0........10........20........30........40                                
 ~~~

--- a/_episodes/02-quality-control.md
+++ b/_episodes/02-quality-control.md
@@ -133,9 +133,9 @@ uses the standard Sanger quality PHRED score encoding, using Illumina version 1.
 Each character is assigned a quality score between 0 and 40 as shown in the chart below.
 
 ~~~
-Quality encoding: @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefgh
-                  |         |         |         |         |
-Quality score:    0........10........20........30........40                                
+Quality encoding: !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJ
+                   |         |         |         |         |
+Quality score:    01........11........21........31........41                                
 ~~~
 {: .output}
 


### PR DESCRIPTION
I know there are larger discussions going on about whether PHRED scores should [even be in this lesson](https://github.com/datacarpentry/wrangling-genomics/issues/141), but in the meantime there has been several instances in our current workshop where folks have been confused by this inconsistent quality key compared with the actual reads. Could we make this tweak in the meantime while waiting for the bigger discussion to play out?
