### PR TITLE
path typo in fastq text episode 05

### DIFF
--- a/_episodes/05-automation.md
+++ b/_episodes/05-automation.md
@@ -331,7 +331,8 @@ mkdir -p sam bam bcf vcf
 {: .output}
 
 Then, we use a loop to run the variant calling workflow on each of our FASTQ files. The full list of commands
-within the loop will be executed once for each of the FASTQ files in the `data/trimmed_fastq/` directory. 
+within the loop will be executed once for each of the FASTQ files in the 
+`data/trimmed_fastq_small/` directory. 
 We will include a few `echo` statements to give us status updates on our progress.
 
 The first thing we do is assign the name of the FASTQ file we're currently working with to a variable called `fq1` and


### PR DESCRIPTION
Just a typo in the path changing `data/trimmed_fastq/` to `data/trimmed_fastq_small/`