### PR TITLE
removal of mac 'open' command (issue 126)

### DIFF
--- a/_episodes/02-quality-control.md
+++ b/_episodes/02-quality-control.md
@@ -344,32 +344,24 @@ $ cd ~/dc_workshop/results/fastqc_untrimmed_reads/
 
 ## Viewing the FastQC results
 
-If we were working on our local computers, we'd be able to display each of these 
-HTML files as a webpage: 
- 
-~~~
-$ open SRR2584863_1_fastqc.html 
-~~~
-{: .bash}
+If we were working on our local computers, we'd be able to look at 
+each of these HTML files by opening them in a web browser.
 
-However, if you try this on our AWS instance, you'll get an error: 
+However, these files are currently sitting on our remote AWS 
+instance, where our local computer can't see them.
+And, since we are only logging into the AWS instance via the 
+command line - it doesn't have any web browser setup to display 
+these files either.
 
-~~~
-Couldn't get a file descriptor referring to the console
-~~~
-{: .output}
-
-This is because the AWS instance we're using doesn't have any web
-browsers installed on it, so the remote computer doesn't know how to 
-open the file. We want to look at the webpage summary reports, so 
-let's transfer them to our local computers (i.e. your laptop).
+So the easiest way to look at these webpage summary reports will be 
+to transfer them to our local computers (i.e. your laptop).
 
 To transfer a file from a remote server to our own machines, we will
 use `scp`, which we learned yesterday in the Shell Genomics lesson. 
 
 First we
 will make a new directory on our computer to store the HTML files
-we're transfering. Let's put it on our desktop for now. Open a new
+we're transferring. Let's put it on our desktop for now. Open a new
 tab in your terminal program (you can use the pull down menu at the
 top of your screen or the Cmd+t keyboard shortcut) and type: 
 
@@ -411,17 +403,11 @@ SRR2589044_2_fastqc.html                      100%  251KB 592.2KB/s   00:00
 ~~~
 {: .output}
 
-Now we can go to our new directory and open the HTML files. 
+Now we can go to our new directory and open the 6 HTML files. 
 
-~~~
-$ cd ~/Desktop/fastqc_html/ 
-$ open *.html 
-~~~
-{: .bash}
-
-Your computer will open each of the HTML files in your default web
-browser. Depending on your settings, this might be as six separate
-tabs in a single window or six separate browser windows.
+Depending on your system, 
+you should be able to select and open them all at once via a right click menu
+in your file browser.
 
 > ## Exercise
 > 

--- a/_episodes/03-trimming.md
+++ b/_episodes/03-trimming.md
@@ -322,10 +322,11 @@ SRR2584863_2un.trim.fastq.gz  SRR2584866_2un.trim.fastq.gz  SRR2589044_2un.trim.
 >> ~~~
 >> $ mkdir ~/Desktop/fastqc_html/trimmed
 >> $ scp dcuser@ec2-34-203-203-131.compute-1.amazonaws.com:~/dc_workshop/data/trimmed_fastq/*.html ~/Desktop/fastqc_html/trimmed
->> $ open ~/Desktop/fastqc_html/trimmed/*.html
 >> ~~~
 >> {: .bash}
->>
+>> 
+>> Then take a look at the html files in your browser.
+>> 
 >> Remember to replace everything between the `@` and `:` in your scp
 >> command with your AWS instance number.
 >>

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -6,7 +6,9 @@ title: "Instructor Notes"
 # Instructor Notes for Wrangling Genomics
 
 ## Issues with Macs vs Windows
-This lesson currently uses the `open` command to view FastQC output on its local browser. The `open` command is great for Macs, but there is currently no command listed in the lesson that works for Macs. The `explore` command may be useful here. If a solution is found, it's worth adding to the lesson.
+
+Users are required to open *multiple* html files locally on their own browser and OS - will vary between users! Probably ctrl-click multiple selection within a file browser and right click will work on most systems?
+
 
 ## SAMtools or IGV?
 Some instructors chose to use SAMtools tview for visualization of variant calling results while other prefer than IGV. SAMtools is the default because installation of IGV can take up additional instruction time, and SAMtools tview is sufficient to visualize results. However, episode 04-variant_calling includes instructions for installation and using IGV.
@@ -57,9 +59,6 @@ $ for filename in *.zip
 ~~~
 
 Because the `>` symbol will cause a syntax error when copied. This command will work correctly when typed at the command line! Learners may be surprised that a for loop takes multiple lines on the terminal.
-
-#### open in View FastQC Results
-The command `open SRR2584863_1_fastqc.html` will present an error in the lesson to illustrate that the AWS instance cannot run the open command because it has no web browser. There is text around this command explaining this issue.
 
 #### unzip in Working with FastQC Output
 The command `unzip *.zip` in the Working with FastQC Output section will run successfully for the first file, but fail for subsequent files. This error introduces the need for a for loop.


### PR DESCRIPTION
This is a suggestion to address issue https://github.com/datacarpentry/wrangling-genomics/issues/126  Thanks.

The genomics carpentry matierial introduces the mac-specific 'open' command to view local html files. But users run this on their own laptops.

Launching a browser from on local files from a terminal window is probably not *that* useful- it can easily be done via whichever OS gui they're used to.

This change removes mention of the open command entirely. Specifically;

- 02-quality-control - Main change: Reworked 'Viewing the FastQC results' to encourace opening the htmls in your local broswer with a right click (should work on most OS?).
 
- 03-trimming.md - 'Bonus Exercise (Advanced)>Solution' Remve reference to open: "open ~/Desktop/fastqc_html/trimmed/*.html",  becomes: "Take a look at the html files in your browser" (it *is* the advanced exercise :))

- Instructer notes - Removed comments about this issue and updated 'Issues with Macs vs Windows' - "Users are required to open *multiple* html files locally on their own browser and OS will vary between users! Probably ctrl-click multiple selection within a file browser and right click will work on most systems?".

