### PR TITLE
Explain filtering variants and show its effects with the TS/TV ratio.

### DIFF
--- a/_episodes/04-variant_calling.md
+++ b/_episodes/04-variant_calling.md
@@ -269,6 +269,19 @@ $ vcfutils.pl varFilter results/bcf/SRR2584866_variants.vcf  > results/vcf/SRR25
 ~~~
 {: .bash}
 
+The `vcfutils.pl varFilter` call filters out variants that do not meet minimum quality default criteria, which can be changed through its options. Using `bcftools` we can verify that the quality of the variant call set has improved after this filtering step by calculating the ratio of [transitions(TS)](https://en.wikipedia.org/wiki/Transition_%28genetics%29) to [transversions (TV)](https://en.wikipedia.org/wiki/Transversion) ratio (TS/TV), where transitions should be more likely to occur than transversions:
+
+~~~
+$ bcftools stats results/bcf/SRR2584866_variants.vcf | grep TSTV
+# TSTV, transitions/transversions:
+# TSTV	[2]id	[3]ts	[4]tv	[5]ts/tv	[6]ts (1st ALT)	[7]tv (1st ALT)	[8]ts/tv (1st ALT)
+TSTV	0	628	58	10.83	628	58	10.83
+$ bcftools stats results/vcf/SRR2584866_final_variants.vcf | grep TSTV
+# TSTV, transitions/transversions:
+# TSTV	[2]id	[3]ts	[4]tv	[5]ts/tv	[6]ts (1st ALT)	[7]tv (1st ALT)	[8]ts/tv (1st ALT)
+TSTV	0	621	54	11.50	621	54	11.50
+~~~
+{: .bash}
 
 ## Explore the VCF format:
 

--- a/_episodes/04-variant_calling.md
+++ b/_episodes/04-variant_calling.md
@@ -269,19 +269,26 @@ $ vcfutils.pl varFilter results/bcf/SRR2584866_variants.vcf  > results/vcf/SRR25
 ~~~
 {: .bash}
 
-The `vcfutils.pl varFilter` call filters out variants that do not meet minimum quality default criteria, which can be changed through its options. Using `bcftools` we can verify that the quality of the variant call set has improved after this filtering step by calculating the ratio of [transitions(TS)](https://en.wikipedia.org/wiki/Transition_%28genetics%29) to [transversions (TV)](https://en.wikipedia.org/wiki/Transversion) ratio (TS/TV), where transitions should be more likely to occur than transversions:
 
-~~~
-$ bcftools stats results/bcf/SRR2584866_variants.vcf | grep TSTV
-# TSTV, transitions/transversions:
-# TSTV	[2]id	[3]ts	[4]tv	[5]ts/tv	[6]ts (1st ALT)	[7]tv (1st ALT)	[8]ts/tv (1st ALT)
-TSTV	0	628	58	10.83	628	58	10.83
-$ bcftools stats results/vcf/SRR2584866_final_variants.vcf | grep TSTV
-# TSTV, transitions/transversions:
-# TSTV	[2]id	[3]ts	[4]tv	[5]ts/tv	[6]ts (1st ALT)	[7]tv (1st ALT)	[8]ts/tv (1st ALT)
-TSTV	0	621	54	11.50	621	54	11.50
-~~~
-{: .bash}
+> ## Filtering 
+> The `vcfutils.pl varFilter` call filters out variants that do not meet minimum quality default criteria, which can be changed through
+>  its options. Using `bcftools` we can verify that the quality of the variant call set has improved after this filtering step by 
+>  calculating the ratio of [transitions(TS)](https://en.wikipedia.org/wiki/Transition_%28genetics%29) to 
+>  [transversions (TV)](https://en.wikipedia.org/wiki/Transversion) ratio (TS/TV), 
+>  where transitions should be more likely to occur than transversions:
+> 
+> ~~~
+> $ bcftools stats results/bcf/SRR2584866_variants.vcf | grep TSTV
+> # TSTV, transitions/transversions:
+> # TSTV	[2]id	[3]ts	[4]tv	[5]ts/tv	[6]ts (1st ALT)	[7]tv (1st ALT)	[8]ts/tv (1st ALT)
+> TSTV	0	628	58	10.83	628	58	10.83
+> $ bcftools stats results/vcf/SRR2584866_final_variants.vcf | grep TSTV
+> # TSTV, transitions/transversions:
+> # TSTV	[2]id	[3]ts	[4]tv	[5]ts/tv	[6]ts (1st ALT)	[7]tv (1st ALT)	[8]ts/tv (1st ALT)
+> TSTV	0	621	54	11.50	621	54	11.50
+> ~~~
+> {: .bash}
+{: .callout}
 
 ## Explore the VCF format:
 


### PR DESCRIPTION
This is a contribution for the instruction training checkout. In this PR I would like to suggest to stress the importance of the step 3 of the variant calling pipeline, where after variants have been called, they are filtered on the basis of several quality control criteria. To that end, this PR proposes to add the following text in this step:

> The `vcfutils.pl varFilter` call filters out variants that do not meet minimum quality default criteria, which can be changed through its options. Using `bcftools` we can verify that the quality of the variant call set has improved after this filtering step by calculating the ratio of [transitions(TS)](https://en.wikipedia.org/wiki/Transition_%28genetics%29) to [transversions (TV)](https://en.wikipedia.org/wiki/Transversion) ratio (TS/TV), where transitions should be more likely to occur than transversions:
>
```
$ bcftools stats results/bcf/SRR2584866_variants.vcf | grep TSTV
# TSTV, transitions/transversions:
# TSTV  [2]id [3]ts [4]tv [5]ts/tv  [6]ts (1st ALT) [7]tv (1st ALT) [8]ts/tv (1st ALT)
TSTV  0 628 58  10.83 628 58  10.83
$ bcftools stats results/vcf/SRR2584866_final_variants.vcf | grep TSTV
# TSTV, transitions/transversions:
# TSTV  [2]id [3]ts [4]tv [5]ts/tv  [6]ts (1st ALT) [7]tv (1st ALT) [8]ts/tv (1st ALT)
TSTV  0 621 54  11.50 621 54  11.50
```

In this lesson `bcftools` are already being used for variant calling and therefore, the additional time required to introduce this idea should be little and should prompt the learner to realize that the quality of the variants can be very heterogeneous and filtering is an important step to obtain a more homogeneous variant call set.