### PR TITLE
Update 03-trimming.md

### DIFF
--- a/_episodes/03-trimming.md
+++ b/_episodes/03-trimming.md
@@ -135,13 +135,18 @@ $ cp ~/.miniconda3/pkgs/trimmomatic-0.38-0/share/trimmomatic-0.38-0/adapters/Nex
 We will also use a sliding window of size 4 that will remove bases if their
 phred score is below 20 (like in our example above). We will also
 discard any reads that do not have at least 25 bases remaining after
-this trimming step. This command will take a few minutes to run.
+this trimming step. Three additional pieces of code are also added to the end
+of the ILLUMINACLIP step. These three additional numbers (2:40:15) tell
+Trimmimatic how to handle sequence matches to the Nextera adapters. A detailed 
+explanation of how they work is advanced for this particular lesson. For now we
+will use these numbers as a default and recognize they are needed to for Trimmomatic
+to run properly. This command will take a few minutes to run.
 
 ~~~
 $ trimmomatic PE SRR2589044_1.fastq.gz SRR2589044_2.fastq.gz \
                 SRR2589044_1.trim.fastq.gz SRR2589044_1un.trim.fastq.gz \
                 SRR2589044_2.trim.fastq.gz SRR2589044_2un.trim.fastq.gz \
-                SLIDINGWINDOW:4:20 MINLEN:25 ILLUMINACLIP:NexteraPE-PE.fa:2:40:15 
+                SLIDINGWINDOW:4:20 MINLEN:25 ILLUMINACLIP:NexteraPE-PE.fa:2:40:15
 ~~~
 {: .bash}
 


### PR DESCRIPTION
There is no explanation of why the seed mismatch, palindrome clip threshold, and simple clip thresholds are being used. I have added a short non detailed description (lines 138-143 )to avoid any confusion.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
