### PR TITLE
change SNP to SNV, remove contractions and make headings sentence case

### DIFF
--- a/_episodes/01-background.md
+++ b/_episodes/01-background.md
@@ -10,7 +10,7 @@ objectives:
 - "Understand the data set."
 - "What is hypermutability?"
 keypoints:
-- "It's important to record and understand your experiment's metadata."
+- "It is important to record and understand your experiment's metadata."
 ---
 
 # Background
@@ -27,7 +27,7 @@ We are going to use a long-term sequencing dataset from a population of *Escheri
  - **Why is *E. coli* important?**
     - *E. coli* are one of the most well-studied model organisms in science. As a single-celled organism, *E. coli* reproduces rapidly, typically doubling its population every 20 minutes, which means it can be manipulated easily in experiments. In addition, most naturally occurring strains of *E. coli* are harmless. Most importantly, the genetics of *E. coli* are fairly well understood and can be manipulated to study adaptation and evolution.
     
-# The Data
+# The data
 
  - The data we are going to use is part of a long-term evolution experiment led by [Richard Lenski](https://en.wikipedia.org/wiki/E._coli_long-term_evolution_experiment).
  
@@ -36,7 +36,7 @@ We are going to use a long-term sequencing dataset from a population of *Escheri
  - To see a timeline of the experiment to date, check out this [figure](https://en.wikipedia.org/wiki/E._coli_long-term_evolution_experiment#/media/File:LTEE_Timeline_as_of_May_28,_2016.png), and this paper [Blount et al. 2008: Historical contingency and the evolution of a key innovation in an experimental population of *Escherichia coli*](http://www.pnas.org/content/105/23/7899).
  
  
-## View the Metadata
+## View the metadata
 
 We will be working with three sample events from the **Ara-3** strain of this experiment, one from 5,000 generations, one from 15,000 generations, and one from 50,000 generations. The population changed substantially during the course of the experiment, and we will be exploring how (the evolution of a **Cit+** mutant and **hypermutability**) with our variant calling workflow. The metadata file associated with this lesson can be [downloaded directly here](https://raw.githubusercontent.com/datacarpentry/wrangling-genomics/gh-pages/files/Ecoli_metadata_composite.csv) or [viewed in Github](https://github.com/datacarpentry/wrangling-genomics/blob/gh-pages/files/Ecoli_metadata_composite.csv). If you would like to know details of how the file was created, you can look at [some notes and sources here](https://github.com/datacarpentry/wrangling-genomics/blob/gh-pages/files/Ecoli_metadata_composite_README.md).
 

--- a/_episodes/02-quality-control.md
+++ b/_episodes/02-quality-control.md
@@ -37,7 +37,7 @@ makes this feasible. Standards ensure that data is stored in a way that is gener
 within the community. The tools that are used to analyze data at different stages of the workflow are therefore 
 built under the assumption that the data will be provided in a specific format.  
 
-# Starting with Data
+# Starting with data
 
 Often times, the first step in a bioinformatic workflow is getting the data you want to work with onto a computer where you can work with it. If you have outsourced sequencing of your data, the sequencing center will usually provide you with a link that you can use to download your data. Today we will be working with publicly available sequencing data.
 
@@ -47,7 +47,7 @@ The data are paired-end, so we will download two files for each sample. We will 
 
 To download the data, run the commands below. 
 
-Here we are using the `-p` option for `mkdir`. This option allows `mkdir` to create the new directory, even if one of the parent directories doesn't already exist. It also supresses errors if the directory already exists, without overwriting that directory. 
+Here we are using the `-p` option for `mkdir`. This option allows `mkdir` to create the new directory, even if one of the parent directories does not already exist. It also supresses errors if the directory already exists, without overwriting that directory. 
 
 It will take about 15 minutes to download the files.
 ~~~
@@ -85,7 +85,7 @@ $ gunzip SRR2584863_1.fastq.gz
 ~~~
 {: .bash}
 
-# Quality Control
+# Quality control
 
 We will now assess the quality of the sequence reads contained in our fastq files. 
 
@@ -234,7 +234,7 @@ DESCRIPTION
                     flag set in the header will be excluded from the analysis.
                     Files must have the same names given to them by casava
                     (including being gzipped and ending with .gz) otherwise they
-                    won't be grouped together correctly.
+                    will not be grouped together correctly.
 
     --nano          Files come from naopore sequences and are in fast5 format. In
                     this mode you can pass in directories to process and the program
@@ -319,11 +319,11 @@ sudo apt-get install fastqc
 
 If this happens check with your instructor before trying to install it. 
 
-## Assessing Quality using FastQC
-In real life, you won't be assessing the quality of your reads by visually inspecting your 
-FASTQ files. Rather, you'll be using a software program to assess read quality and 
-filter out poor quality reads. We'll first use a program called [FastQC](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/) to visualize the quality of our reads. 
-Later in our workflow, we'll use another program to filter out poor quality reads. 
+## Assessing quality using FastQC
+In real life, you will not be assessing the quality of your reads by visually inspecting your 
+FASTQ files. Rather, you will be using a software program to assess read quality and 
+filter out poor quality reads. We will first use a program called [FastQC](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/) to visualize the quality of our reads. 
+Later in our workflow, we will use another program to filter out poor quality reads. 
 
 FastQC has a number of features which can give you a quick impression of any problems your
 data may have, so you can take these issues into consideration before moving forward with your
@@ -354,7 +354,7 @@ Here, we see positions within the read in which the boxes span a much wider rang
 
 ## Running FastQC  
 
-We will now assess the quality of the reads that we downloaded. First, make sure you're still in the `untrimmed_fastq` directory
+We will now assess the quality of the reads that we downloaded. First, make sure you are still in the `untrimmed_fastq` directory
 
 ~~~
 $ cd ~/dc_workshop/data/untrimmed_fastq/ 
@@ -447,7 +447,7 @@ SRR2584863_2.fastq.gz     SRR2584866_2.fastq.gz     SRR2589044_2.fastq.gz
 
 For each input FASTQ file, FastQC has created a `.zip` file and a
 `.html` file. The `.zip` file extension indicates that this is 
-actually a compressed set of multiple output files. We'll be working
+actually a compressed set of multiple output files. We will be working
 with these output files soon. The `.html` file is a stable webpage
 displaying the summary report for each of our samples.
 
@@ -472,13 +472,13 @@ $ cd ~/dc_workshop/results/fastqc_untrimmed_reads/
 
 ## Viewing the FastQC results
 
-If we were working on our local computers, we'd be able to look at 
+If we were working on our local computers, we would be able to look at 
 each of these HTML files by opening them in a web browser.
 
 However, these files are currently sitting on our remote AWS 
-instance, where our local computer can't see them.
+instance, where our local computer can not see them.
 And, since we are only logging into the AWS instance via the 
-command line - it doesn't have any web browser setup to display 
+command line - it does not have any web browser setup to display 
 these files either.
 
 So the easiest way to look at these webpage summary reports will be 
@@ -489,7 +489,7 @@ use `scp`, which we learned yesterday in the Shell Genomics lesson.
 
 First we
 will make a new directory on our computer to store the HTML files
-we're transferring. Let's put it on our desktop for now. Open a new
+we are transferring. Let's put it on our desktop for now. Open a new
 tab in your terminal program (you can use the pull down menu at the
 top of your screen or the Cmd+t keyboard shortcut) and type: 
 
@@ -511,7 +511,7 @@ the address for your remote computer. Make sure you replace everything
 after `dcuser@` with your instance number (the one you used to log in). 
 
 The second part starts with a `:` and then gives the absolute path
-of the files you want to transfer from your remote computer. Don't
+of the files you want to transfer from your remote computer. Do not
 forget the `:`. We used a wildcard (`*.html`) to indicate that we want all of
 the HTML files. 
 
@@ -550,7 +550,7 @@ in your file browser.
 {: .challenge}
 
 ## Decoding the other FastQC outputs
-We've now looked at quite a few "Per base sequence quality" FastQC graphs, but there are nine other graphs that we haven't talked about! Below we have provided a brief overview of interpretations for each of these plots. For more information, please see the FastQC documentation [here](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/) 
+We have now looked at quite a few "Per base sequence quality" FastQC graphs, but there are nine other graphs that we have not talked about! Below we have provided a brief overview of interpretations for each of these plots. For more information, please see the FastQC documentation [here](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/) 
 
 + [**Per tile sequence quality**](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/12%20Per%20Tile%20Sequence%20Quality.html): the machines that perform sequencing are divided into tiles. This plot displays patterns in base quality along these tiles. Consistently low scores are often found around the edges, but hot spots can also occur in the middle if an air bubble was introduced at some point during the run. 
 + [**Per sequence quality scores**](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/3%20Per%20Sequence%20Quality%20Scores.html): a density plot of quality for all reads at all positions. This plot shows what quality scores are most common. 
@@ -565,10 +565,10 @@ We've now looked at quite a few "Per base sequence quality" FastQC graphs, but t
 
 ## Working with the FastQC text output
 
-Now that we've looked at our HTML reports to get a feel for the data,
+Now that we have looked at our HTML reports to get a feel for the data,
 let's look more closely at the other output files. Go back to the tab
 in your terminal program that is connected to your AWS instance
-(the tab label will start with `dcuser@ip`) and make sure you're in
+(the tab label will start with `dcuser@ip`) and make sure you are in
 our results subdirectory.   
 
 ~~~
@@ -606,15 +606,15 @@ caution: filename not matched:  SRR2589044_2_fastqc.zip
 ~~~
 {: .output}
 
-This didn't work. We unzipped the first file and then got a warning
+This did not work. We unzipped the first file and then got a warning
 message for each of the other `.zip` files. This is because `unzip` 
 expects to get only one zip file as input. We could go through and 
 unzip each file one at a time, but this is very time consuming and 
 error-prone. Someday you may have 500 files to unzip!
 
 A more efficient way is to use a `for` loop like we learned in the Shell Genomics lesson to iterate through all of
-our `.zip` files. Let's see what that looks like and then we'll 
-discuss what we're doing with each line of our loop.
+our `.zip` files. Let's see what that looks like and then we will 
+discuss what we are doing with each line of our loop.
 
 ~~~
 $ for filename in *.zip
@@ -665,7 +665,7 @@ Archive:  SRR2589044_2_fastqc.zip
 The `unzip` program is decompressing the `.zip` files and creating
 a new directory (with subdirectories) for each of our samples, to 
 store all of the different output that is produced by FastQC. There
-are a lot of files here. The one we're going to focus on is the 
+are a lot of files here. The one we are going to focus on is the 
 `summary.txt` file. 
 
 If you list the files in our directory now you will see: 
@@ -682,7 +682,7 @@ SRR2584863_2_fastqc.zip   SRR2584866_2_fastqc.zip   SRR2589044_2_fastqc.zip
 
 The `.html` files and the uncompressed `.zip` files are still present,
 but now we also have a new directory for each of our samples. We can 
-see for sure that it's a directory if we use the `-F` flag for `ls`. 
+see for sure that it is a directory if we use the `-F` flag for `ls`. 
 
 ~~~
 $ ls -F 
@@ -736,11 +736,11 @@ WARN    Adapter Content SRR2584863_1.fastq
 The summary file gives us a list of tests that FastQC ran, and tells
 us whether this sample passed, failed, or is borderline (`WARN`). Remember, to quit from `less` you must type `q`.
 
-## Documenting Our Work
+## Documenting our work
 
 We can make a record of the results we obtained for all our samples
 by concatenating all of our `summary.txt` files into a single file 
-using the `cat` command. We'll call this `fastqc_summaries.txt` and move
+using the `cat` command. We will call this `fastqc_summaries.txt` and move
 it to `~/dc_workshop/docs`.
 
 ~~~
@@ -783,24 +783,24 @@ $ cat */summary.txt > ~/dc_workshop/docs/fastqc_summaries.txt
 {: .challenge}
 
 
-# Other notes  -- Optional 
+# Other notes  -- optional 
 
-> ## Quality Encodings Vary
+> ## Quality encodings vary
 >
-> Although we've used a particular quality encoding system to demonstrate interpretation of 
+> Although we have used a particular quality encoding system to demonstrate interpretation of 
 > read quality, different sequencing machines use different encoding systems. This means that, 
 > depending on which sequencer you use to generate your data, a `#` may not be an indicator of 
 > a poor quality base call.
 >
 > This mainly relates to older Solexa/Illumina data,
-> but it's essential that you know which sequencing platform was
+> but it is essential that you know which sequencing platform was
 > used to generate your data, so that you can tell your quality control program which encoding
 > to use. If you choose the wrong encoding, you run the risk of throwing away good reads or 
 > (even worse) not throwing away bad reads!
 {: .callout}
 
 
-> ## Same Symbols, Different Meanings
+> ## Same symbols, different meanings
 >
 > Here we see `>` being used as a shell prompt, whereas `>` is also
 > used to redirect output.

--- a/_episodes/03-trimming.md
+++ b/_episodes/03-trimming.md
@@ -3,7 +3,7 @@ title: "Trimming and Filtering"
 teaching: 30
 exercises: 25
 questions:
-- "How can I get rid of sequence data that doesn't meet my quality standards?"
+- "How can I get rid of sequence data that does not meet my quality standards?"
 objectives:
 - "Clean FASTQ reads using Trimmomatic."
 - "Select and set multiple options for command-line bioinformatic tools."
@@ -13,20 +13,20 @@ keypoints:
 - "Data cleaning is an essential step in a genomics workflow."
 ---
 
-# Cleaning Reads
+# Cleaning reads
 
 In the previous episode, we took a high-level look at the quality
 of each of our samples using FastQC. We visualized per-base quality
 graphs showing the distribution of read quality at each base across
 all reads in a sample and extracted information about which samples
-fail which quality checks. Some of our samples failed quite a few quality metrics used by FastQC. This doesn't mean,
-though, that our samples should be thrown out! It's very common to have some quality metrics fail, and this may or may not be a problem for your downstream application. For our variant calling workflow, we will be removing some of the low quality sequences to reduce our false positive rate due to sequencing error.
+fail which quality checks. Some of our samples failed quite a few quality metrics used by FastQC. This does not mean,
+though, that our samples should be thrown out! It is very common to have some quality metrics fail, and this may or may not be a problem for your downstream application. For our variant calling workflow, we will be removing some of the low quality sequences to reduce our false positive rate due to sequencing error.
 
 We will use a program called
 [Trimmomatic](http://www.usadellab.org/cms/?page=trimmomatic) to
 filter poor quality reads and trim poor quality bases from our samples.
 
-## Trimmomatic Options
+## Trimmomatic options
 
 Trimmomatic has a variety of options to trim your reads. If we run the following command, we can see some of our options.
 
@@ -89,7 +89,7 @@ $ trimmomatic PE -threads 4 SRR_1056_1.fastq SRR_1056_2.fastq  \
 ~~~
 {: .bash}
 
-In this example, we've told Trimmomatic:
+In this example, we have told Trimmomatic:
 
 | code   | meaning |
 | ------- | ---------- |
@@ -194,7 +194,7 @@ SRR2589044_1.trim.fastq.gz  SRR2589044_2.fastq.gz         SRR2589044_2un.trim.fa
 {: .output}
 
 The output files are also FASTQ files. It should be smaller than our
-input file, because we've removed reads. We can confirm this:
+input file, because we have removed reads. We can confirm this:
 
 ~~~
 $ ls SRR2589044* -l -h
@@ -212,7 +212,7 @@ $ ls SRR2589044* -l -h
 {: .output}
 
 
-We've just successfully run Trimmomatic on one of our FASTQ files!
+We have just successfully run Trimmomatic on one of our FASTQ files!
 However, there is some bad news. Trimmomatic can only operate on
 one sample at a time and we have more than one sample. The good news
 is that we can use a `for` loop to iterate through our sample files
@@ -239,8 +239,8 @@ $ for infile in *_1.fastq.gz
 
 
 Go ahead and run the for loop. It should take a few minutes for
-Trimmomatic to run for each of our six input files. Once it's done
-running, take a look at your directory contents. You'll notice that even though we ran Trimmomatic on file `SRR2589044` before running the for loop, there is only one set of files for it. Because we matched the ending `_1.fastq.gz`, we re-ran Trimmomatic on this file, overwriting our first results. That's ok, but it's good to be aware that it happened.
+Trimmomatic to run for each of our six input files. Once it is done
+running, take a look at your directory contents. You will notice that even though we ran Trimmomatic on file `SRR2589044` before running the for loop, there is only one set of files for it. Because we matched the ending `_1.fastq.gz`, we re-ran Trimmomatic on this file, overwriting our first results. That is ok, but it is good to be aware that it happened.
 
 ~~~
 $ ls
@@ -279,7 +279,7 @@ SRR2584863_2un.trim.fastq.gz  SRR2589044_1.fastq.gz
 > {: .solution}
 {: .challenge}
 
-We've now completed the trimming and filtering steps of our quality
+We have now completed the trimming and filtering steps of our quality
 control process! Before we move on, let's move our trimmed FASTQ files
 to a new subdirectory within our `data/` directory.
 
@@ -300,7 +300,7 @@ SRR2584863_2un.trim.fastq.gz  SRR2584866_2un.trim.fastq.gz  SRR2589044_2un.trim.
 ~~~
 {: .output}
 
-> ## Bonus Exercise (Advanced)
+> ## Bonus exercise (advanced)
 >
 > Now that our samples have gone through quality control, they should perform
 > better on the quality tests run by FastQC. Go ahead and re-run

--- a/_episodes/04-variant_calling.md
+++ b/_episodes/04-variant_calling.md
@@ -10,8 +10,8 @@ objectives:
 - "Use command line tools to perform variant calling."
 keypoints:
 - "Bioinformatic command line tools are collections of commands that can be used to carry out bioinformatic analyses."
-- "To use most powerful bioinformatic tools, you'll need to use the command line."
-- "There are many different file formats for storing genomics data. It's important to understand what type of information is contained in each file, and how it was derived."
+- "To use most powerful bioinformatic tools, you will need to use the command line."
+- "There are many different file formats for storing genomics data. It is important to understand what type of information is contained in each file, and how it was derived."
 ---
 
 We mentioned before that we are working with files from a long-term evolution study of an *E. coli* population (designated Ara-3). Now that we have looked at our data to make sure that it is high quality, and removed low-quality base calls, we can perform variant calling to see how the population changed over time. We care how this population changed relative to the original population, *E. coli* strain REL606. Therefore, we will align each of our samples to the *E. coli* REL606 reference genome, and see what differences exist in our reads versus the genome.
@@ -120,8 +120,8 @@ Have a look at the [bwa options page](http://bio-bwa.sourceforge.net/bwa.shtml).
 parameters here, your use case might require a change of parameters. *NOTE: Always read the manual page for any tool before using 
 and make sure the options you use are appropriate for your data.*
 
-We're going to start by aligning the reads from just one of the 
-samples in our dataset (`SRR2584866`). Later, we'll be 
+We are going to start by aligning the reads from just one of the 
+samples in our dataset (`SRR2584866`). Later, we will be 
 iterating this whole process on all of our sample files.
 
 ~~~
@@ -187,7 +187,7 @@ $ samtools sort -o results/bam/SRR2584866.aligned.sorted.bam results/bam/SRR2584
 ~~~
 {: .bash}
 
-Our files are pretty small, so we won't see this output. If you run the workflow with larger files, you will see something like this:
+Our files are pretty small, so we will not see this output. If you run the workflow with larger files, you will see something like this:
 ~~~
 [bam_sort_core] merging from 2 files...
 ~~~
@@ -224,7 +224,7 @@ This will give you the following statistics about your sorted bam file:
 ## Variant calling
 
 A variant call is a conclusion that there is a nucleotide difference vs. some reference at a given position in an individual genome
-or transcriptome, often referred to as a Single Nucleotide Polymorphism (SNP). The call is usually accompanied by an estimate of 
+or transcriptome, often referred to as a Single Nucleotide Variant (SNV). The call is usually accompanied by an estimate of 
 variant frequency and some measure of confidence. Similar to other steps in this workflow, there are a number of tools available for 
 variant calling. In this workshop we will be using `bcftools`, but there are a few things we need to do before actually calling the 
 variants.
@@ -251,18 +251,18 @@ $ bcftools mpileup -O b -o results/bcf/SRR2584866_raw.bcf \
 
 We have now generated a file with coverage information for every base.
 
-### Step 2: Detect the single nucleotide polymorphisms (SNPs)
+### Step 2: Detect the single nucleotide variants (SNVs)
 
-Identify SNPs using bcftools `call`. We have to specify ploidy with the flag `--ploidy`, which is one for the haploid *E. coli*. `-m` allows for multiallelic and rare-variant calling, `-v` tells the program to output variant sites only (not every site in the genome), and `-o` specifies where to write the output file:
+Identify SNVs using bcftools `call`. We have to specify ploidy with the flag `--ploidy`, which is one for the haploid *E. coli*. `-m` allows for multiallelic and rare-variant calling, `-v` tells the program to output variant sites only (not every site in the genome), and `-o` specifies where to write the output file:
 
 ~~~
 $ bcftools call --ploidy 1 -m -v -o results/bcf/SRR2584866_variants.vcf results/bcf/SRR2584866_raw.bcf 
 ~~~
 {: .bash}
 
-### Step 3: Filter and report the SNP variants in variant calling format (VCF)
+### Step 3: Filter and report the SNV variants in variant calling format (VCF)
 
-Filter the SNPs for the final output in VCF format, using `vcfutils.pl`:
+Filter the SNVs for the final output in VCF format, using `vcfutils.pl`:
 
 ~~~
 $ vcfutils.pl varFilter results/bcf/SRR2584866_variants.vcf  > results/vcf/SRR2584866_final_variants.vcf
@@ -370,7 +370,7 @@ to learn more about the VCF file format.
 
 > ## Exercise
 > 
-> Use the `grep` and `wc` commands you've learned to assess how many variants are in the vcf file. 
+> Use the `grep` and `wc` commands you have learned to assess how many variants are in the vcf file. 
 >
 >> ## Solution
 >> 
@@ -448,7 +448,7 @@ AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGCTTCTGAACTG
 The first line of output shows the genome coordinates in our reference genome. The second line shows the reference
 genome sequence. The third line shows the consensus sequence determined from the sequence reads. A `.` indicates
 a match to the reference sequence, so we can see that the consensus from our sample matches the reference in most
-locations. That is good! If that wasn't the case, we should probably reconsider our choice of reference.
+locations. That is good! If that was not the case, we should probably reconsider our choice of reference.
 
 Below the horizontal line, we can see all of the reads in our sample aligned with the reference genome. Only 
 positions where the called base differs from the reference are shown. You can use the arrow keys on your keyboard
@@ -479,9 +479,9 @@ this box, type the name of the "chromosome" followed by a colon and the position
 [IGV](http://www.broadinstitute.org/igv/) is a stand-alone browser, which has the advantage of being installed locally and providing fast access. Web-based genome browsers, like [Ensembl](http://www.ensembl.org/index.html) or the [UCSC browser](https://genome.ucsc.edu/), are slower, but provide more functionality. They not only allow for more polished and flexible visualization, but also provide easy access to a wealth of annotations and external data sources. This makes it straightforward to relate your data with information about repeat regions, known genes, epigenetic features or areas of cross-species conservation, to name just a few.
 
 In order to use IGV, we will need to transfer some files to our local machine. We know how to do this with `scp`. 
-Open a new tab in your terminal window and create a new folder. We'll put this folder on our Desktop for 
+Open a new tab in your terminal window and create a new folder. We will put this folder on our Desktop for 
 demonstration purposes, but in general you should avoide proliferating folders and files on your Desktop and 
-instead organize files within a directory structure like we've been using in our `dc_workshop` directory.
+instead organize files within a directory structure like we have been using in our `dc_workshop` directory.
 
 ~~~
 $ mkdir ~/Desktop/files_for_igv
@@ -503,7 +503,7 @@ $ scp dcuser@ec2-34-203-203-131.compute-1.amazonaws.com:~/dc_workshop/results/vc
 
 You will need to type the password for your AWS instance each time you call `scp`. 
 
-Next, we need to open the IGV software. If you haven't done so already, you can download IGV from the [Broad Institute's software page](https://www.broadinstitute.org/software/igv/download), double-click the `.zip` file
+Next, we need to open the IGV software. If you have not done so already, you can download IGV from the [Broad Institute's software page](https://www.broadinstitute.org/software/igv/download), double-click the `.zip` file
 to unzip it, and then drag the program into your Applications folder. 
 
 1. Open IGV.
@@ -525,26 +525,26 @@ Zoom in to inspect variants you see in your filtered VCF file to become more fam
 corresponds to alignment information at those loci.
 Use [this website](http://software.broadinstitute.org/software/igv/AlignmentData) and the links therein to understand how IGV colors the alignments.
 
-Now that we've run through our workflow for a single sample, we want to repeat this workflow for our other five
-samples. However, we don't want to type each of these individual steps again five more times. That would be very
+Now that we have run through our workflow for a single sample, we want to repeat this workflow for our other five
+samples. However, we do not want to type each of these individual steps again five more times. That would be very
 time consuming and error-prone, and would become impossible as we gathered more and more samples. Luckily, we
 already know the tools we need to use to automate this workflow and run it on as many files as we want using a
-single line of code. Those tools are: wildcards, for loops, and bash scripts. We'll use all three in the next 
+single line of code. Those tools are: wildcards, for loops, and bash scripts. We will use all three in the next 
 lesson. 
 
-> ## Installing Software
+> ## Installing software
 > 
-> It's worth noting that all of the software we are using for
+> It is worth noting that all of the software we are using for
 > this workshop has been pre-installed on our remote computer. 
 > This saves us a lot of time - installing software can be a 
 > time-consuming and frustrating task - however, this does mean that
-> you won't be able to walk out the door and start doing these
-> analyses on your own computer. You'll need to install 
+> you will not be able to walk out the door and start doing these
+> analyses on your own computer. You will need to install 
 > the software first. Look at the [setup instructions](http://www.datacarpentry.org/wrangling-genomics/setup.html) for more information 
 > on installing these software packages.
 {: .callout}
 
-> ## BWA Alignment options
+> ## BWA alignment options
 > BWA consists of three algorithms: BWA-backtrack, BWA-SW and BWA-MEM. The first algorithm is designed for Illumina sequence 
 > reads up to 100bp, while the other two are for sequences ranging from 70bp to 1Mbp. BWA-MEM and BWA-SW share similar features such 
 > as long-read support and split alignment, but BWA-MEM, which is the latest, is generally recommended for high-quality queries as it 

--- a/_episodes/05-automation.md
+++ b/_episodes/05-automation.md
@@ -16,7 +16,7 @@ keypoints:
 You wrote a simple shell script in a [previous lesson](http://www.datacarpentry.org/shell-genomics/05-writing-scripts/) that we used to extract bad reads from our
 FASTQ files and put them into a new file. 
 
-Here's the script you wrote:
+Here is the script you wrote:
 
 ~~~
 grep -B1 -A2 NNNNNNNNNN *.fastq > scripted_bad_reads.txt
@@ -35,10 +35,10 @@ long. If we wanted to do this for all six of our data files, that would be forty
 steps. If we had 50 samples (a more realistic number), it would be 400 steps! You can
 see why we want to automate this.
 
-We've also used `for` loops in previous lessons to iterate one or two commands over multiple input files. 
+We have also used `for` loops in previous lessons to iterate one or two commands over multiple input files. 
 In these `for` loops, the filename was defined as a variable in the `for` statement, which enabled you to run the loop on multiple files. We will be using variable assignments like this in our new shell scripts.
 
-Here's the `for` loop you wrote for unzipping `.zip` files: 
+Here is the `for` loop you wrote for unzipping `.zip` files: 
 
 ~~~
 $ for filename in *.zip
@@ -48,7 +48,7 @@ $ for filename in *.zip
 ~~~
 {: .bash}
 
-And here's the one you wrote for running Trimmomatic on all of our `.fastq` sample files:
+And here is the one you wrote for running Trimmomatic on all of our `.fastq` sample files:
 
 ~~~
 $ for infile in *_1.fastq.gz
@@ -64,16 +64,16 @@ $ for infile in *_1.fastq.gz
 
 Notice that in this `for` loop, we used two variables, `infile`, which was defined in the `for` statement, and `base`, which was created from the filename during each iteration of the loop.
 
-> ## Creating Variables
+> ## Creating variables
 > Within the Bash shell you can create variables at any time (as we did
 > above, and during the 'for' loop lesson). Assign any name and the
 > value using the assignment operator: '='. You can check the current
 > definition of your variable by typing into your script: echo $variable_name.
 {: .callout}
 
-In this lesson, we'll use two shell scripts to automate the variant calling analysis: one for FastQC analysis (including creating our summary file), and a second for the remaining variant calling. To write a script to run our FastQC analysis, we'll take each of the commands we entered to run FastQC and process the output files and put them into a single file with a `.sh` extension. The `.sh` is not essential, but serves as a reminder to ourselves and to the computer that this is a shell script.
+In this lesson, we will use two shell scripts to automate the variant calling analysis: one for FastQC analysis (including creating our summary file), and a second for the remaining variant calling. To write a script to run our FastQC analysis, we will take each of the commands we entered to run FastQC and process the output files and put them into a single file with a `.sh` extension. The `.sh` is not essential, but serves as a reminder to ourselves and to the computer that this is a shell script.
 
-# Analyzing Quality with FastQC
+# Analyzing quality with FastQC
 
 We will use the command `touch` to create a new file where we will write our shell script. We will create this script in a new
 directory called `scripts/`. Previously, we used
@@ -119,7 +119,7 @@ fastqc *.fastq*
 ~~~
 {: .output}
 
-Our next line will create a new directory to hold our FastQC output files. Here we are using the `-p` option for `mkdir` again. It is a good idea to use this option in your shell scripts to avoid running into errors if you don't have the directory structure you think you do.
+Our next line will create a new directory to hold our FastQC output files. Here we are using the `-p` option for `mkdir` again. It is a good idea to use this option in your shell scripts to avoid running into errors if you do not have the directory structure you think you do.
 
 ~~~
 mkdir -p ~/dc_workshop/results/fastqc_untrimmed_reads
@@ -136,14 +136,14 @@ mv *.html ~/dc_workshop/results/fastqc_untrimmed_reads/
 ~~~
 {: .output}
 
-The next line moves us to the results directory where we've stored our output.
+The next line moves us to the results directory where we have stored our output.
 
 ~~~
 cd ~/dc_workshop/results/fastqc_untrimmed_reads/
 ~~~
 {: .output}
 
-The next five lines should look very familiar. First we give ourselves a status message to tell us that we're unzipping our ZIP
+The next five lines should look very familiar. First we give ourselves a status message to tell us that we are unzipping our ZIP
 files. Then we run our for loop to unzip all of the `.zip` files in this directory.
 
 ~~~
@@ -156,7 +156,7 @@ for filename in *.zip
 {: .output}
 
 Next we concatenate all of our summary files into a single output file, with a status message to remind ourselves that this is 
-what we're doing.
+what we are doing.
 
 ~~~
 echo "Saving summary..."
@@ -166,7 +166,7 @@ cat */summary.txt > ~/dc_workshop/docs/fastqc_summaries.txt
 
 > ## Using `echo` statements
 > 
-> We've used `echo` statements to add progress statements to our script. Our script will print these statements
+> We have used `echo` statements to add progress statements to our script. Our script will print these statements
 > as it is running and therefore we will be able to see how far our script has progressed.
 >
 {: .callout}
@@ -230,7 +230,7 @@ replace SRR2584866_fastqc/Icons/fastqc_icon.png? [y]es, [n]o, [A]ll, [N]one, [r]
 {: .output}
 
 
-# Automating the Rest of our Variant Calling Workflow
+# Automating the rest of our variant calling workflow
 
 We can extend these principles to the entire variant calling workflow. To do this, we will take all of the individual commands that we wrote before, put them into a single file, add variables so that the script knows to iterate through our input files and write to the appropriate output files. This is very similar to what we did with our `read_qc.sh` script, but will be a bit more complex.
 
@@ -247,8 +247,8 @@ Our variant calling workflow has the following steps:
 2. Align reads to reference genome.
 3. Convert the format of the alignment to sorted BAM, with some intermediate steps.
 4. Calculate the read coverage of positions in the genome.
-5. Detect the single nucleotide polymorphisms (SNPs).
-6. Filter and report the SNP variants in VCF (variant calling format).
+5. Detect the single nucleotide variants (SNVs).
+6. Filter and report the SNVs in VCF (variant calling format).
 
 Let's go through this script together:
 
@@ -298,7 +298,7 @@ for fq1 in ~/dc_workshop/data/trimmed_fastq_small/*_1.trim.sub.fastq
 ~~~
 {: .output}
 
-Now, we'll go through each line in the script before running it.
+Now, we will go through each line in the script before running it.
 
 First, notice that we change our working directory so that we can create new results subdirectories
 in the right location. 
@@ -335,8 +335,8 @@ within the loop will be executed once for each of the FASTQ files in the
 `data/trimmed_fastq_small/` directory. 
 We will include a few `echo` statements to give us status updates on our progress.
 
-The first thing we do is assign the name of the FASTQ file we're currently working with to a variable called `fq1` and
-tell the script to `echo` the filename back to us so we can check which file we're on.
+The first thing we do is assign the name of the FASTQ file we are currently working with to a variable called `fq1` and
+tell the script to `echo` the filename back to us so we can check which file we are on.
 
 ~~~
 for fq1 in ~/dc_workshop/data/trimmed_fastq_small/*_1.trim.sub.fastq
@@ -353,7 +353,7 @@ to a new variable called `base`.
 ~~~
 {: .bash}
 
-We can use the `base` variable to access both the `base_1.fastq` and `base_2.fastq` input files, and create variables to store the names of our output files. This makes the script easier to read because we don't need to type out the full name of each of the files: instead, we use the `base` variable, but add a different extension (e.g. `.sam`, `.bam`) for each file produced by our workflow.
+We can use the `base` variable to access both the `base_1.fastq` and `base_2.fastq` input files, and create variables to store the names of our output files. This makes the script easier to read because we do not need to type out the full name of each of the files: instead, we use the `base` variable, but add a different extension (e.g. `.sam`, `.bam`) for each file produced by our workflow.
 
 
 ~~~
@@ -409,14 +409,14 @@ And finally, the actual workflow steps:
 ~~~
 {: .output}
 
-6) call SNPs with bcftools:
+6) call SNVs with bcftools:
 
 ~~~
     bcftools call --ploidy 1 -m -v -o $variants $raw_bcf 
 ~~~
 {: .output}
 
-7) filter and report the SNP variants in variant calling format (VCF):
+7) filter and report the SNVs in variant calling format (VCF):
 
 ~~~
     vcfutils.pl varFilter $variants  > $final_variants
@@ -426,7 +426,7 @@ And finally, the actual workflow steps:
 
 
 > ## Exercise
-> It's a good idea to add comments to your code so that you (or a collaborator) can make sense of what you did later. 
+> It is a good idea to add comments to your code so that you (or a collaborator) can make sense of what you did later. 
 > Look through your existing script. Discuss with a neighbor where you should add comments. Add comments (anything following
 > a `#` character will be interpreted as a comment, bash will not try to run these comments as code). 
 {: .challenge}
@@ -468,11 +468,11 @@ $ bash run_variant_calling.sh
 {: .challenge}
 
 
-> ## Bonus Exercise
+> ## Bonus exercise
 > 
 > If you have time after completing the previous exercise, use `run_variant_calling.sh` to run the variant calling pipeline 
 > on the full-sized trimmed FASTQ files. You should have a copy of these already in `~/dc_workshop/data/trimmed_fastq`, but if 
-> you don't, there is a copy in `~/.solutions/wrangling-solutions/trimmed_fastq`. Does the number of variants change per sample?
+> you do not, there is a copy in `~/.solutions/wrangling-solutions/trimmed_fastq`. Does the number of variants change per sample?
 {: .challenge} 
 
 


### PR DESCRIPTION
I would like to change 'single nucleotide polymorphism' to 'single nucleotide variant' to reflect the fact the we are also identifying variants at lower variant frequencies for consistency with terminology used by most variant callers. Also it avoids the 'SNP variants' statements that occur in places.

I've also changed the headings/sub-headings to sentence-case for consistency across and within episodes and removed contractions for accessibility as referenced[here](https://github.com/carpentries/carpentries.org/issues/993).




