### PR TITLE
change the output directory for vcf to vcf

### DIFF
--- a/_episodes/04-variant_calling.md
+++ b/_episodes/04-variant_calling.md
@@ -256,7 +256,7 @@ We have now generated a file with coverage information for every base.
 Identify SNPs using bcftools `call`. We have to specify ploidy with the flag `--ploidy`, which is one for the haploid *E. coli*. `-m` allows for multiallelic and rare-variant calling, `-v` tells the program to output variant sites only (not every site in the genome), and `-o` specifies where to write the output file:
 
 ~~~
-$ bcftools call --ploidy 1 -m -v -o results/bcf/SRR2584866_variants.vcf results/bcf/SRR2584866_raw.bcf 
+$ bcftools call --ploidy 1 -m -v -o results/vcf/SRR2584866_variants.vcf results/bcf/SRR2584866_raw.bcf 
 ~~~
 {: .bash}
 


### PR DESCRIPTION
`$ bcftools call....` command's output is in vcf format but the output path is pointing to the bcf directory. Direct it to vcf to avoid confusion :)

