### PR TITLE
Step 3: Filter and report the incorrect directory in hightlight section

### DIFF
--- a/episodes/04-variant_calling.md
+++ b/episodes/04-variant_calling.md
@@ -271,7 +271,7 @@ calculating the ratio of [transitions(TS)](https://en.wikipedia.org/wiki/Transit
 where transitions should be more likely to occur than transversions:
 
 ```bash
-$ bcftools stats results/bcf/SRR2584866_variants.vcf | grep TSTV
+$ bcftools stats results/vcf/SRR2584866_variants.vcf | grep TSTV
 # TSTV, transitions/transversions:
 # TSTV	[2]id	[3]ts	[4]tv	[5]ts/tv	[6]ts (1st ALT)	[7]tv (1st ALT)	[8]ts/tv (1st ALT)
 TSTV	0	628	58	10.83	628	58	10.83


### PR DESCRIPTION
In step 3 of Variant calling in the section called filtering beginning at line 265 on the github script, where we compare the quality of the of the variants called before and after filtering, the directory name is wrong when running the unfiltered variants.  Line 274 currently has /bcf/ instead /vcf/.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
