### PR TITLE
fix file path

### DIFF
--- a/episodes/03-trimming.md
+++ b/episodes/03-trimming.md
@@ -274,7 +274,7 @@ What other adapter files came with Trimmomatic?
 ## Solution
 
 ```bash
-$ ls ~/miniconda3/pkgs/trimmomatic-0.38-0/share/trimmomatic-0.38-0/adapters/
+$ ls ~/.miniconda3/pkgs/trimmomatic-0.38-0/share/trimmomatic-0.38-0/adapters/
 ```
 
 ```output


### PR DESCRIPTION
miniconda is a hidden directory and needs the `.`, as shown in output below

<img width="1022" alt="Screenshot 2024-06-12 at 11 44 28 AM" src="https://github.com/datacarpentry/wrangling-genomics/assets/19176319/8e05c039-46dc-42c6-a92b-86ee12bcaaab">
