### PR TITLE
Create docs directory

### DIFF
--- a/episodes/05-automation.md
+++ b/episodes/05-automation.md
@@ -158,6 +158,7 @@ what we are doing.
 
 ```output
 echo "Saving summary..."
+mkdir -p ~/dc_workshops/docs
 cat */summary.txt > ~/dc_workshop/docs/fastqc_summaries.txt
 ```
 


### PR DESCRIPTION
The `read_qc.sh` script is inconsistent in creating new directories. Before creating the `results/fastqc_untrimmed_reads` directory, there is a note that says: 

> "Our next line will create a new directory to hold our FastQC output files. Here we are using the -p option for mkdir again. It is a good idea to use this option in your shell scripts to avoid running into errors if you do not have the directory structure you think you do."

But then the last line in the script cats the summaries to a new file within the `/docs/` directory without first creating that directory. This will run without error for most learners, if they have been following along with the materials, but will fail if someone is using the script independently of the lesson. This PR adds a command to create that `/docs/` directory, to be on the safe side and consistent with advice earlier in the episode. 