### PR TITLE
Update link target for setup instructions

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -5,6 +5,6 @@ title: Setup
 This workshop is designed to be run on pre-imaged Amazon Web Services
 (AWS) instances. For information about how to
 use the workshop materials, see the
-[setup instructions](https://www.datacarpentry.org/genomics-workshop/setup.html) on the main workshop page.
+[setup instructions](https://www.datacarpentry.org/genomics-workshop/index.html#setup) on the main workshop page.
 
 


### PR DESCRIPTION
As reported by a community member over email. The link to the workshop setup instructions was outdated.